### PR TITLE
V1.0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # This file specifies intentionally untracked directories and files that Git should ignore.
 
 # Specific directories that should be ignored
+.claude/
 .vscode/
 coverage/
 dist/

--- a/README.md
+++ b/README.md
@@ -109,12 +109,6 @@ If auto-discovery doesn't find your vacuum, add it manually:
     "enabled": true,
     "warningThreshold": 10,
     "exposeAsContactSensors": false,
-    "maxLifetimes": {
-      "mainBrush": 18000,
-      "sideBrush": 12000,
-      "dustFilter": 9000,
-      "sensor": 1800
-    }
   },
   "mapCache": {
     "enabled": true,
@@ -160,9 +154,20 @@ Apple Home requires **server mode** to be enabled. This creates a separate Matte
 
 The plugin exposes the following cleaning modes based on your vacuum's capabilities:
 
-- **Vacuum Only** - Quiet, Auto, Quick, Max intensities
-- **Mop Only** - Min, Low, Medium, High water levels
-- **Vacuum & Mop** - Combined modes with intensity variants
+- **Vacuum Only** 
+- **Mop Only** 
+- **Vacuum & Mop**
+- **Vacuum then Mop**
+
+### Presets
+By default the plugin maps Valetudo presets to Matter RVC modes using the following map:
+- `min` &rarr; Min
+- `low` &rarr; Quiet
+- `medium` &rarr; Auto
+- `high` &rarr; Quick
+- `max` &rarr; Max
+- `turbo` &rarr; DeepClean
+- `custom` &rarr; LowNoise
 
 ### Room Selection
 

--- a/matterbridge-valetudo.schema.json
+++ b/matterbridge-valetudo.schema.json
@@ -135,92 +135,6 @@
           "description": "Create contact sensors for each consumable (open = needs replacement, closed = OK)",
           "type": "boolean",
           "default": false
-        },
-        "maxLifetimes": {
-          "title": "Maximum Lifetimes (minutes)",
-          "description": "Expected lifetime for each consumable type",
-          "type": "object",
-          "properties": {
-            "mainBrush": {
-              "title": "Main Brush",
-              "description": "Default: 18,000 minutes (300 hours)",
-              "type": "number",
-              "default": 18000,
-              "minimum": 60
-            },
-            "sideBrush": {
-              "title": "Side Brush",
-              "description": "Default: 12,000 minutes (200 hours)",
-              "type": "number",
-              "default": 12000,
-              "minimum": 60
-            },
-            "dustFilter": {
-              "title": "Dust Filter",
-              "description": "Default: 9,000 minutes (150 hours)",
-              "type": "number",
-              "default": 9000,
-              "minimum": 60
-            },
-            "sensor": {
-              "title": "Sensor Cleaning",
-              "description": "Default: 1,800 minutes (30 hours)",
-              "type": "number",
-              "default": 1800,
-              "minimum": 60
-            }
-          }
-        }
-      }
-    },
-    "customTags": {
-      "title": "Custom mode tags",
-      "description": "Manually map Valetudo presets to Matter Tags",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "operationMode": {
-            "title": "Operation Mode Context",
-            "description": "Which operation mode does this apply to?",
-            "type": "array",
-            "uniqueItems": true,
-            "items": {
-              "type": "string",
-              "enum": ["vacuum", "mop", "vacuum_and_mop"]
-            },
-            "default": ["vacuum", "mop", "vacuum_and_mop"]
-          },
-          "fanSpeed": {
-            "title": "Fan Speed",
-            "description": "e.g., 'low', 'medium', 'high', 'max'",
-            "type": "string",
-            "default": "medium"
-          },
-          "waterUsage": {
-            "title": "Water Usage",
-            "description": "For mop modes: 'min', 'low', 'medium', 'high', 'max'",
-            "type": "string",
-            "default": "medium"
-          },
-          "matterModeTag": {
-            "title": "Matter Mode",
-            "type": "number",
-            "oneOf": [
-              { "const": 0, "title": "Auto" },
-              { "const": 1, "title": "Quick" },
-              { "const": 2, "title": "Quiet" },
-              { "const": 3, "title": "LowNoise" },
-              { "const": 4, "title": "LowEnergy" },
-              { "const": 5, "title": "Vacation" },
-              { "const": 6, "title": "Min" },
-              { "const": 7, "title": "Max" },
-              { "const": 8, "title": "Night" },
-              { "const": 9, "title": "Day" },
-              { "const": 16384, "title": "DeepClean"}
-            ],
-            "default": 0
-          }
         }
       }
     },
@@ -251,31 +165,61 @@
         }
       }
     },
-    "modeMapping": {
-      "title": "Operation Mode Mapping",
-      "description": "Map Valetudo operation modes to Matter clean mode categories. Useful for robots that support vacuum_then_mop mode.",
-      "type": "object",
-      "properties": {
-        "vacuum": {
-          "title": "Vacuum Category Source",
-          "description": "Valetudo mode for Matter Vacuum modes (default: vacuum)",
-          "type": "string",
-          "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"],
-          "default": "vacuum"
-        },
-        "mop": {
-          "title": "Mop Category Source",
-          "description": "Valetudo mode for Matter Mop modes (default: mop)",
-          "type": "string",
-          "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"],
-          "default": "mop"
-        },
-        "vacuumAndMop": {
-          "title": "Vacuum & Mop Category Source",
-          "description": "Valetudo mode for Matter Vacuum & Mop modes (default: vacuum_and_mop)",
-          "type": "string",
-          "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"],
-          "default": "vacuum_and_mop"
+    "customTags": {
+      "title": "Custom Mode Tags",
+      "description": "Manually map valetudo presets to matter tags",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["operationModes"],
+        "properties": {
+          "operationModes": {
+            "title": "Operation Modes",
+            "description": "Which valetudo operation mode(s) does this mapping apply to?",
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"]
+            },
+            "default": ["vacuum", "mop", "vacuum_and_mop"]
+          },
+          "mappings": {
+            "title": "Preset Mappings",
+            "description": "Define the fan speed and/or water usage mappings for the selected mode(s)",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "fanSpeed": {
+                  "title": "Fan Speed",
+                  "description": "e.g., 'low', 'medium', 'high', 'max'",
+                  "type": "string",
+                  "default": "medium"
+                },
+                "waterUsage": {
+                  "title": "Water Usage",
+                  "description": "For mop modes: 'min', 'low', 'medium', 'high', 'max'",
+                  "type": "string",
+                  "default": "medium"
+                },
+                "matterModeTag": {
+                  "title": "Matter Mode",
+                  "type": "number",
+                  "oneOf": [
+                    { "const": 0, "title": "Auto" },
+                    { "const": 1, "title": "Quick" },
+                    { "const": 2, "title": "Quiet" },
+                    { "const": 6, "title": "Min" },
+                    { "const": 7, "title": "Max" },
+                    { "const": 16384, "title": "DeepClean"}
+                  ],
+                  "default": 0
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/matterbridge-valetudo.schema.json
+++ b/matterbridge-valetudo.schema.json
@@ -202,35 +202,63 @@
         }
       }
     },
-    "modeOverrides": {
-      "title": "Clean Mode Overrides",
-      "description": "Customize what the vacuum does when a specific clean mode is selected in your smart home controller. By default, each intensity level maps directly to the matching Valetudo preset (e.g. Quick → fan speed 'high'). Use this to change that behavior.",
+    "operationModeMapping": {
+      "title": "Operation Mode Mapping",
+      "description": "Map each Matter cleaning category (as shown in your controller) to a Valetudo operation mode. Useful if your vacuum supports 'vacuum_then_mop' and you want it under the 'Vacuum & Mop' category.",
+      "type": "object",
+      "properties": {
+        "vacuum": {
+          "title": "Vacuum",
+          "description": "Valetudo mode to use for the Vacuum category (default: vacuum)",
+          "type": "string",
+          "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"],
+          "default": "vacuum"
+        },
+        "mop": {
+          "title": "Mop",
+          "description": "Valetudo mode to use for the Mop category (default: mop)",
+          "type": "string",
+          "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"],
+          "default": "mop"
+        },
+        "vacuumAndMop": {
+          "title": "Vacuum & Mop",
+          "description": "Valetudo mode to use for the Vacuum & Mop category (default: vacuum_and_mop)",
+          "type": "string",
+          "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"],
+          "default": "vacuum_and_mop"
+        }
+      }
+    },
+    "intensityOverrides": {
+      "title": "Intensity Overrides",
+      "description": "Override the fan speed or water usage for specific intensity levels. By default, each intensity maps to its matching Valetudo preset (e.g. Quick → fan 'high'). Use this to change that.",
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["operationMode", "intensity"],
+        "required": ["intensity"],
         "properties": {
-          "operationMode": {
-            "title": "Operation Mode",
-            "description": "Which cleaning category to override",
+          "category": {
+            "title": "Category",
+            "description": "Which Matter category to override (leave empty to apply to all categories)",
             "type": "string",
-            "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"]
+            "enum": ["vacuum", "mop", "vacuumAndMop"]
           },
           "intensity": {
-            "title": "Intensity Level",
-            "description": "Which intensity level to override (as shown in your controller)",
+            "title": "Intensity",
+            "description": "Which intensity level to override (as shown in your controller: Min, Quiet/Low, Auto/Medium, Quick/High, Max, Deep Clean/Turbo, Custom)",
             "type": "string",
             "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"]
           },
           "fanSpeed": {
-            "title": "Fan Speed Override",
-            "description": "Fan speed to send to the vacuum (leave empty to keep default)",
+            "title": "Fan Speed",
+            "description": "Fan speed to send to the vacuum",
             "type": "string",
             "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"]
           },
           "waterUsage": {
-            "title": "Water Usage Override",
-            "description": "Water usage to send to the vacuum (leave empty to keep default)",
+            "title": "Water Usage",
+            "description": "Water usage to send to the vacuum",
             "type": "string",
             "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"]
           }

--- a/matterbridge-valetudo.schema.json
+++ b/matterbridge-valetudo.schema.json
@@ -246,9 +246,17 @@
           },
           "intensity": {
             "title": "Intensity",
-            "description": "Which intensity level to override (as shown in your controller: Min, Quiet/Low, Auto/Medium, Quick/High, Max, Deep Clean/Turbo, Custom)",
+            "description": "Which intensity level to override, as shown in your smart home controller",
             "type": "string",
-            "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"]
+            "oneOf": [
+              { "const": "Min", "title": "Min" },
+              { "const": "Quiet", "title": "Quiet (default for 'low')" },
+              { "const": "Auto", "title": "Auto (default for 'medium')" },
+              { "const": "Quick", "title": "Quick (default for 'high')" },
+              { "const": "Max", "title": "Max" },
+              { "const": "DeepClean", "title": "Deep Clean (default for 'turbo')" },
+              { "const": "LowNoise", "title": "Custom / Low Noise" }
+            ]
           },
           "fanSpeed": {
             "title": "Fan Speed",

--- a/matterbridge-valetudo.schema.json
+++ b/matterbridge-valetudo.schema.json
@@ -231,14 +231,16 @@
               "properties": {
                 "fanSpeed": {
                   "title": "Fan Speed",
-                  "description": "e.g., 'low', 'medium', 'high', 'max'",
+                  "description": "Fan speed preset for vacuum modes",
                   "type": "string",
+                  "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"],
                   "default": "medium"
                 },
                 "waterUsage": {
                   "title": "Water Usage",
-                  "description": "For mop modes: 'min', 'low', 'medium', 'high', 'max'",
+                  "description": "Water usage preset for mop modes",
                   "type": "string",
+                  "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"],
                   "default": "medium"
                 },
                 "matterModeTag": {

--- a/matterbridge-valetudo.schema.json
+++ b/matterbridge-valetudo.schema.json
@@ -202,62 +202,37 @@
         }
       }
     },
-    "customTags": {
-      "title": "Custom Mode Tags",
-      "description": "Manually map valetudo presets to matter tags",
+    "modeOverrides": {
+      "title": "Clean Mode Overrides",
+      "description": "Customize what the vacuum does when a specific clean mode is selected in your smart home controller. By default, each intensity level maps directly to the matching Valetudo preset (e.g. Quick → fan speed 'high'). Use this to change that behavior.",
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["operationModes"],
+        "required": ["operationMode", "intensity"],
         "properties": {
-          "operationModes": {
-            "title": "Operation Modes",
-            "description": "Which valetudo operation mode(s) does this mapping apply to?",
-            "type": "array",
-            "uniqueItems": true,
-            "minItems": 1,
-            "items": {
-              "type": "string",
-              "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"]
-            },
-            "default": ["vacuum", "mop", "vacuum_and_mop"]
+          "operationMode": {
+            "title": "Operation Mode",
+            "description": "Which cleaning category to override",
+            "type": "string",
+            "enum": ["vacuum", "mop", "vacuum_and_mop", "vacuum_then_mop"]
           },
-          "mappings": {
-            "title": "Preset Mappings",
-            "description": "Define the fan speed and/or water usage mappings for the selected mode(s)",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "fanSpeed": {
-                  "title": "Fan Speed",
-                  "description": "Fan speed preset for vacuum modes",
-                  "type": "string",
-                  "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"],
-                  "default": "medium"
-                },
-                "waterUsage": {
-                  "title": "Water Usage",
-                  "description": "Water usage preset for mop modes",
-                  "type": "string",
-                  "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"],
-                  "default": "medium"
-                },
-                "matterModeTag": {
-                  "title": "Matter Mode",
-                  "type": "number",
-                  "oneOf": [
-                    { "const": 0, "title": "Auto" },
-                    { "const": 1, "title": "Quick" },
-                    { "const": 2, "title": "Quiet" },
-                    { "const": 6, "title": "Min" },
-                    { "const": 7, "title": "Max" },
-                    { "const": 16384, "title": "DeepClean"}
-                  ],
-                  "default": 0
-                }
-              }
-            }
+          "intensity": {
+            "title": "Intensity Level",
+            "description": "Which intensity level to override (as shown in your controller)",
+            "type": "string",
+            "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"]
+          },
+          "fanSpeed": {
+            "title": "Fan Speed Override",
+            "description": "Fan speed to send to the vacuum (leave empty to keep default)",
+            "type": "string",
+            "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"]
+          },
+          "waterUsage": {
+            "title": "Water Usage Override",
+            "description": "Water usage to send to the vacuum (leave empty to keep default)",
+            "type": "string",
+            "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"]
           }
         }
       }

--- a/matterbridge-valetudo.schema.json
+++ b/matterbridge-valetudo.schema.json
@@ -135,6 +135,43 @@
           "description": "Create contact sensors for each consumable (open = needs replacement, closed = OK)",
           "type": "boolean",
           "default": false
+        },
+        "maxLifetimes": {
+          "title": "Maximum Lifetimes (minutes)",
+          "description": "Override API-reported max lifetime for consumable types. If not set, the value reported by the vacuum is used.",
+          "type": "object",
+          "properties": {
+            "mainBrush": {
+              "title": "Main Brush",
+              "description": "Default: use API value",
+              "type": "number",
+              "minimum": 60
+            },
+            "sideBrush": {
+              "title": "Side Brush",
+              "description": "Default: use API value",
+              "type": "number",
+              "minimum": 60
+            },
+            "dustFilter": {
+              "title": "Dust Filter",
+              "description": "Default: use API value",
+              "type": "number",
+              "minimum": 60
+            },
+            "sensor": {
+              "title": "Sensor Cleaning",
+              "description": "Default: use API value",
+              "type": "number",
+              "minimum": 60
+            },
+            "mop": {
+              "title": "Mop",
+              "description": "Default: use API value",
+              "type": "number",
+              "minimum": 60
+            }
+          }
         }
       }
     },

--- a/matterbridge-valetudo.schema.json
+++ b/matterbridge-valetudo.schema.json
@@ -173,75 +173,53 @@
         }
       }
     },
-    "intensityPresets": {
-      "title": "Intensity Presets (Advanced)",
-      "description": "Override default fan speed and water usage for each intensity level",
-      "type": "object",
-      "properties": {
-        "auto": {
-          "title": "Auto Intensity",
-          "type": "object",
-          "properties": {
-            "fanSpeed": {
-              "title": "Fan Speed",
-              "description": "e.g., 'low', 'medium', 'high', 'max'",
+    "customTags": {
+      "title": "Custom mode tags",
+      "description": "Manually map Valetudo presets to Matter Tags",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "operationMode": {
+            "title": "Operation Mode Context",
+            "description": "Which operation mode does this apply to?",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
               "type": "string",
-              "default": "medium"
+              "enum": ["vacuum", "mop", "vacuum_and_mop"]
             },
-            "waterUsage": {
-              "title": "Water Usage",
-              "description": "For mop modes: 'min', 'low', 'medium', 'high', 'max'",
-              "type": "string",
-              "default": "medium"
-            }
-          }
-        },
-        "quiet": {
-          "title": "Quiet Intensity",
-          "type": "object",
-          "properties": {
-            "fanSpeed": {
-              "title": "Fan Speed",
-              "type": "string",
-              "default": "low"
-            },
-            "waterUsage": {
-              "title": "Water Usage",
-              "type": "string",
-              "default": "low"
-            }
-          }
-        },
-        "quick": {
-          "title": "Quick Intensity",
-          "type": "object",
-          "properties": {
-            "fanSpeed": {
-              "title": "Fan Speed",
-              "type": "string",
-              "default": "high"
-            },
-            "waterUsage": {
-              "title": "Water Usage",
-              "type": "string",
-              "default": "high"
-            }
-          }
-        },
-        "max": {
-          "title": "Max Intensity",
-          "type": "object",
-          "properties": {
-            "fanSpeed": {
-              "title": "Fan Speed",
-              "type": "string",
-              "default": "max"
-            },
-            "waterUsage": {
-              "title": "Water Usage",
-              "type": "string",
-              "default": "high"
-            }
+            "default": ["vacuum", "mop", "vacuum_and_mop"]
+          },
+          "fanSpeed": {
+            "title": "Fan Speed",
+            "description": "e.g., 'low', 'medium', 'high', 'max'",
+            "type": "string",
+            "default": "medium"
+          },
+          "waterUsage": {
+            "title": "Water Usage",
+            "description": "For mop modes: 'min', 'low', 'medium', 'high', 'max'",
+            "type": "string",
+            "default": "medium"
+          },
+          "matterModeTag": {
+            "title": "Matter Mode",
+            "type": "number",
+            "oneOf": [
+              { "const": 0, "title": "Auto" },
+              { "const": 1, "title": "Quick" },
+              { "const": 2, "title": "Quiet" },
+              { "const": 3, "title": "LowNoise" },
+              { "const": 4, "title": "LowEnergy" },
+              { "const": 5, "title": "Vacation" },
+              { "const": 6, "title": "Min" },
+              { "const": 7, "title": "Max" },
+              { "const": 8, "title": "Night" },
+              { "const": 9, "title": "Day" },
+              { "const": 16384, "title": "DeepClean"}
+            ],
+            "default": 0
           }
         }
       }

--- a/matterbridge-valetudo.schema.json
+++ b/matterbridge-valetudo.schema.json
@@ -262,13 +262,13 @@
             "title": "Fan Speed",
             "description": "Fan speed to send to the vacuum",
             "type": "string",
-            "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"]
+            "enum": ["low", "medium", "high", "max"]
           },
           "waterUsage": {
             "title": "Water Usage",
             "description": "Water usage to send to the vacuum",
             "type": "string",
-            "enum": ["min", "low", "medium", "high", "max", "turbo", "custom"]
+            "enum": ["min", "low", "medium", "high", "max"]
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-valetudo",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-valetudo",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "multicast-dns": "^7.2.5"
@@ -598,7 +598,6 @@
       "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -614,7 +613,6 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -626,7 +624,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -640,7 +637,6 @@
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -654,7 +650,6 @@
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -668,7 +663,6 @@
       "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -693,7 +687,6 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -705,7 +698,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -732,7 +724,6 @@
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -743,7 +734,6 @@
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -758,7 +748,6 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -769,7 +758,6 @@
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
@@ -784,7 +772,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -799,7 +786,6 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -1268,8 +1254,7 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1500,6 +1485,7 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -2160,6 +2146,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2183,7 +2170,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2201,7 +2187,6 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2227,8 +2212,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "Python-2.0",
-      "peer": true
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -2385,7 +2369,7 @@
       }
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
@@ -2486,7 +2470,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2507,7 +2490,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2525,7 +2507,6 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2538,8 +2519,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/comment-parser": {
       "version": "1.4.1",
@@ -2564,7 +2544,6 @@
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2651,8 +2630,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -3048,6 +3026,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3333,7 +3312,6 @@
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -3364,7 +3342,6 @@
       "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3378,7 +3355,6 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3390,7 +3366,6 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3404,7 +3379,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3462,7 +3436,6 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -3515,8 +3488,7 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -3560,16 +3532,14 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -3587,7 +3557,6 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -3614,7 +3583,6 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -3632,7 +3600,6 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -3646,8 +3613,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3807,7 +3773,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -3821,7 +3786,6 @@
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4014,7 +3978,6 @@
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -4032,7 +3995,6 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -4535,7 +4497,6 @@
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4558,24 +4519,21 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4583,7 +4541,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -4594,7 +4551,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -4609,7 +4565,6 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -4625,8 +4580,7 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -4914,7 +4868,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -4961,7 +4914,6 @@
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -4978,7 +4930,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -4995,7 +4946,6 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -5026,7 +4976,6 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5037,13 +4986,12 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
@@ -5121,7 +5069,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -5132,6 +5079,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5172,7 +5120,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5294,7 +5241,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5509,7 +5455,6 @@
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5523,7 +5468,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5920,7 +5864,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -6045,6 +5988,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6106,7 +6050,7 @@
       }
     },
     "node_modules/ts-declaration-location": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
       "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
       "dev": true,
@@ -6183,7 +6127,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -6249,7 +6192,7 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
@@ -6275,6 +6218,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6494,7 +6438,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -6505,6 +6448,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6598,6 +6542,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6611,6 +6556,7 @@
       "integrity": "sha512-IUSop8jgaT7w0g1yOM/35qVtKjr/8Va4PrjzH1OUb0YH4c3OXB2lCZDkMAB6glA8T5w8S164oJGsbcmAecr4sA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.3",
         "@vitest/mocker": "4.0.3",
@@ -6702,7 +6648,6 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -6825,7 +6770,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6843,7 +6787,6 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-valetudo",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Matterbridge plugin for Valetudo-enabled robot vacuums",
   "author": "JGtHb",
   "license": "Apache-2.0",

--- a/src/module.ts
+++ b/src/module.ts
@@ -33,6 +33,7 @@ interface VacuumInstance {
   // Per-vacuum state
   capabilities: string[];
   operationModes: string[];
+  modeMap: Map<number, { fanSpeed?: string; waterUsage?: string; operationMode?: string }>;
   areaToSegmentMap: Map<number, { id: string; name: string }>;
   selectedSegmentIds: string[];
   selectedRoomNames: string[];
@@ -64,31 +65,7 @@ const enum RvcRunModeValue {
   Mapping = 3,
 }
 
-/**
- * RvcCleanMode values
- * Organized by cleaning type with intensity variants
- */
-const enum RvcCleanModeValue {
-  // Vacuum & Mop combined modes (5-9)
-  VacuumMopQuiet = 5,
-  VacuumMopAuto = 6,
-  VacuumMopQuick = 7,
-  VacuumMopMax = 8,
-  VacuumMopTurbo = 9,
-
-  // Mop only modes (31-34)
-  MopMin = 31,
-  MopLow = 32,
-  MopMedium = 33,
-  MopHigh = 34,
-
-  // Vacuum only modes (66-70)
-  VacuumQuiet = 66,
-  VacuumAuto = 67,
-  VacuumQuick = 68,
-  VacuumMax = 69,
-  VacuumTurbo = 70,
-}
+const RvcCleanModeBase = 5;
 
 /**
  * Matter Operational State enum values
@@ -298,18 +275,23 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       }
     }
 
-    // Fetch robot info
-    const robotInfo = await client.getRobotInfo();
-    if (!robotInfo) {
-      throw new Error(`Failed to fetch robot info from ${ip}`);
-    }
-
     // Determine device name
     let deviceName: string;
     if (customName) {
       deviceName = customName;
     } else {
-      deviceName = `${robotInfo.manufacturer} ${robotInfo.modelName}`;
+      const customizations = await client.getCustomizations();
+      if (customizations?.friendlyName) {
+        deviceName = customizations.friendlyName;
+      } else {
+        // Fetch robot info
+        // Only need to fetch info if no customName or friendlyName is set
+        const robotInfo = await client.getRobotInfo();
+        if (!robotInfo) {
+          throw new Error(`Failed to fetch robot info from ${ip}`);
+        }
+        deviceName = `${robotInfo.manufacturer} ${robotInfo.modelName}`;
+      }
     }
 
     // Create vacuum instance
@@ -323,6 +305,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       capabilities: [],
       operationModes: [],
       areaToSegmentMap: new Map(),
+      modeMap: new Map(),
       selectedSegmentIds: [],
       selectedRoomNames: [],
       consumableMap: new Map(),
@@ -473,78 +456,125 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
       let fanSpeedPresets: string[] | null = null;
       let waterUsagePresets: string[] | null = null;
+      const operatingModes = vacuum.capabilities.includes('OperationModeControlCapability') ? await vacuum.client.getOperationModePresets() : null;
 
       if (vacuum.capabilities.includes('FanSpeedControlCapability')) {
-        fanSpeedPresets = await vacuum.client.getFanSpeedPresets();
+        const presets = await vacuum.client.getFanSpeedPresets();
+        if (presets) {
+          fanSpeedPresets = presets.filter((preset) => preset !== 'off');
+        }
       }
-
       if (vacuum.capabilities.includes('WaterUsageControlCapability')) {
-        waterUsagePresets = await vacuum.client.getWaterUsagePresets();
+        const presets = await vacuum.client.getWaterUsagePresets();
+        if (presets) {
+          waterUsagePresets = presets.filter((preset) => preset !== 'off');
+        }
       }
+      const modeMapping = this.getModeMapping();
+      const operationModeMap: Record<string, string | undefined> = {
+        vacuum: operatingModes?.includes(modeMapping.vacuum) ? modeMapping.vacuum : undefined,
+        mop: operatingModes?.includes(modeMapping.mop) ? modeMapping.mop : undefined,
+        vacuumAndMop: operatingModes?.includes(modeMapping.vacuumAndMop) ? modeMapping.vacuumAndMop : undefined,
+      };
 
-      if (vacuum.capabilities.includes('OperationModeControlCapability')) {
-        const operationModes = await vacuum.client.getOperationModePresets();
-        if (operationModes && operationModes.length > 0) {
-          vacuum.operationModes = operationModes;
-          const modeMapping = this.getModeMapping();
+      const presetToTagMap: Record<string, number> = {
+        off: RvcCleanMode.ModeTag.Min,
+        min: RvcCleanMode.ModeTag.Min,
+        low: RvcCleanMode.ModeTag.Quiet,
+        medium: RvcCleanMode.ModeTag.Auto,
+        high: RvcCleanMode.ModeTag.Quick,
+        max: RvcCleanMode.ModeTag.Max,
+        turbo: RvcCleanMode.ModeTag.Max,
+      };
+      if (fanSpeedPresets) {
+        const modeIdBase = RvcCleanModeBase + vacuum.modeMap.size;
+        fanSpeedPresets.forEach((preset, index) => {
+          const tag = presetToTagMap[preset] || RvcCleanMode.ModeTag.Auto;
+          const modeId = modeIdBase + index;
+          const label = `Vacuum (${RvcCleanMode.ModeTag[tag]})`;
+          supportedCleanModes.push({
+            label: label,
+            mode: modeId,
+            modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }, { value: tag }],
+          });
 
-          // Vacuum category (Matter modes 66-70)
-          const vacuumSource = modeMapping.vacuum;
-          if (operationModes.includes(vacuumSource) || (vacuumSource === 'vacuum' && operationModes.includes('vaccum'))) {
-            supportedCleanModes.push(...this.createIntensityVariants(vacuumSource, RvcCleanModeValue.VacuumQuiet, [RvcCleanMode.ModeTag.Vacuum], fanSpeedPresets));
-            if (vacuumSource !== 'vacuum') {
-              this.log.info(`[${vacuum.name}] Vacuum category: using '${vacuumSource}'`);
-            }
-          } else if (vacuumSource !== 'vacuum') {
-            this.log.warn(`[${vacuum.name}] Vacuum category: configured mode '${vacuumSource}' not supported by robot`);
-          }
+          vacuum.modeMap.set(modeId, {
+            fanSpeed: preset,
+            waterUsage: undefined,
+            operationMode: operationModeMap['vacuum'],
+          });
+        });
+      }
+      if (operatingModes?.includes(modeMapping.mop)) {
+        const modeIdBase = RvcCleanModeBase + vacuum.modeMap.size;
+        if (waterUsagePresets) {
+          waterUsagePresets.forEach((preset, index) => {
+            const tag = presetToTagMap[preset] || RvcCleanMode.ModeTag.Auto;
+            const modeId = modeIdBase + index;
+            const label = `Mop (${RvcCleanMode.ModeTag[tag]})`;
+            supportedCleanModes.push({
+              label: label,
+              mode: modeId,
+              modeTags: [{ value: RvcCleanMode.ModeTag.Mop }, { value: tag }],
+            });
 
-          // Mop category (Matter modes 31-34)
-          const mopSource = modeMapping.mop;
-          if (operationModes.includes(mopSource)) {
-            supportedCleanModes.push(...this.createMopVariants(fanSpeedPresets, waterUsagePresets));
-            if (mopSource !== 'mop') {
-              this.log.info(`[${vacuum.name}] Mop category: using '${mopSource}'`);
-            }
-          } else if (mopSource !== 'mop') {
-            this.log.warn(`[${vacuum.name}] Mop category: configured mode '${mopSource}' not supported by robot`);
-          }
-
-          // Vacuum & Mop category (Matter modes 5-9)
-          const vacuumMopSource = modeMapping.vacuumAndMop;
-          if (operationModes.includes(vacuumMopSource)) {
-            supportedCleanModes.push(
-              ...this.createIntensityVariants(vacuumMopSource, RvcCleanModeValue.VacuumMopQuiet, [RvcCleanMode.ModeTag.Mop, RvcCleanMode.ModeTag.Vacuum], fanSpeedPresets),
-            );
-            if (vacuumMopSource !== 'vacuum_and_mop') {
-              this.log.info(`[${vacuum.name}] Vacuum & Mop category: using '${vacuumMopSource}'`);
-            }
-          } else if (vacuumMopSource !== 'vacuum_and_mop') {
-            this.log.warn(`[${vacuum.name}] Vacuum & Mop category: configured mode '${vacuumMopSource}' not supported by robot`);
+            vacuum.modeMap.set(modeId, {
+              fanSpeed: undefined,
+              waterUsage: preset,
+              operationMode: operationModeMap['mop'],
+            });
+          });
+        } else {
+          supportedCleanModes.push({
+            label: `Mop (Auto)`,
+            mode: modeIdBase,
+            modeTags: [{ value: RvcCleanMode.ModeTag.Mop }, { value: RvcCleanMode.ModeTag.Auto }],
+          });
+          vacuum.modeMap.set(modeIdBase, {
+            fanSpeed: undefined,
+            waterUsage: 'med',
+            operationMode: operationModeMap['mop'],
+          });
+        }
+      }
+      if (operatingModes?.includes(modeMapping.vacuumAndMop)) {
+        const modeIdBase = RvcCleanModeBase + vacuum.modeMap.size;
+        if (fanSpeedPresets && waterUsagePresets) {
+          const nFanSpeeds = fanSpeedPresets.length;
+          const nWaterLevels = waterUsagePresets.length;
+          for (let i = 0; i < Math.max(nFanSpeeds, nWaterLevels); i++) {
+            const fanSpeed = fanSpeedPresets[i] ?? fanSpeedPresets[nFanSpeeds - 1];
+            const waterUsage = waterUsagePresets[i] ?? waterUsagePresets[nWaterLevels - 1];
+            const tag = presetToTagMap[fanSpeedPresets[i] ?? waterUsagePresets[i]];
+            const modeId = modeIdBase + i;
+            const label = `Vacuum & Mop (${RvcCleanMode.ModeTag[tag]})`;
+            supportedCleanModes.push({
+              label: label,
+              mode: modeId,
+              modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }, { value: RvcCleanMode.ModeTag.Mop }, { value: tag }],
+            });
+            vacuum.modeMap.set(modeId, {
+              fanSpeed: fanSpeed,
+              waterUsage: waterUsage,
+              operationMode: operationModeMap['vacuumAndMop'],
+            });
           }
         }
       }
-
-      // Deduplicate modes by label (Matter requires unique labels)
-      const seenLabels = new Set<string>();
-      const deduplicatedModes = supportedCleanModes.filter((mode) => {
-        if (seenLabels.has(mode.label)) {
-          this.log.debug(`[${vacuum.name}] Skipping duplicate mode label: ${mode.label}`);
-          return false;
-        }
-        seenLabels.add(mode.label);
-        return true;
-      });
-      supportedCleanModes.length = 0;
-      supportedCleanModes.push(...deduplicatedModes);
 
       if (supportedCleanModes.length === 0) {
         supportedCleanModes.push({
           label: 'Vacuum',
-          mode: 66,
+          mode: RvcCleanModeBase,
           modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }, { value: RvcCleanMode.ModeTag.Auto }],
         });
+        vacuum.modeMap.set(RvcCleanModeBase, {
+          fanSpeed: undefined,
+          waterUsage: undefined,
+          operationMode: undefined,
+        });
       }
+      this.log.debug(`Supported clean modes: ${JSON.stringify(supportedCleanModes)}`);
 
       // Create Matter device
       const useServerMode = (this.config as { enableServerMode?: boolean }).enableServerMode === true;
@@ -553,9 +583,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         vacuum.name,
         vacuum.id,
         useServerMode ? 'server' : undefined,
-        1,
+        RvcRunModeValue.Idle,
         supportedRunModes,
-        supportedCleanModes.length > 0 ? supportedCleanModes[0].mode : 1,
+        supportedCleanModes[0].mode, // we already check .length > 0
         supportedCleanModes,
         null,
         null,
@@ -702,19 +732,24 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         }
       } else {
         // Clean mode change
-        const settings = this.getIntensitySettings(request.newMode);
-        const mode = this.getBaseModeFromNumber(request.newMode);
+        const modeConfig = vacuum.modeMap.get(request.newMode);
+        const fanSpeed = modeConfig?.fanSpeed;
+        const waterUsage = modeConfig?.waterUsage;
 
-        if (mode) {
-          this.log.info(`[${vacuum.name}] Setting mode '${mode}' with fan '${settings.fan}', water '${settings.water}'`);
-          await vacuum.client.setOperationMode(mode);
-
-          if (settings.fan && vacuum.capabilities.includes('FanSpeedControlCapability')) {
-            await vacuum.client.setFanSpeed(settings.fan);
+        if (modeConfig) {
+          if (modeConfig.operationMode) {
+            this.log.info(`[${vacuum.name}] Setting mode '${modeConfig.operationMode}'`);
+            await vacuum.client.setOperationMode(modeConfig.operationMode);
           }
 
-          if (settings.water && vacuum.capabilities.includes('WaterUsageControlCapability')) {
-            await vacuum.client.setWaterUsage(settings.water);
+          if (fanSpeed && vacuum.capabilities.includes('FanSpeedControlCapability')) {
+            this.log.info(`[${vacuum.name}] Setting fan '${fanSpeed}'`);
+            await vacuum.client.setFanSpeed(fanSpeed);
+          }
+
+          if (waterUsage && vacuum.capabilities.includes('WaterUsageControlCapability')) {
+            this.log.info(`[${vacuum.name}] Setting water '${waterUsage}'`);
+            await vacuum.client.setWaterUsage(waterUsage);
           }
         }
       }
@@ -766,17 +801,6 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
       this.log.info(`[${vacuum.name}] Selected rooms: ${roomNames.join(', ')}`);
     });
-  }
-
-  /**
-   * Get base mode from mode number
-   */
-  private getBaseModeFromNumber(mode: number): string {
-    const modeMapping = this.getModeMapping();
-    if (mode >= 66 && mode <= 70) return modeMapping.vacuum;
-    if (mode >= 31 && mode <= 42) return modeMapping.mop;
-    if (mode >= 5 && mode <= 9) return modeMapping.vacuumAndMop;
-    return '';
   }
 
   /**
@@ -1199,106 +1223,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
   }
 
   /**
-   * Create intensity variants for a cleaning mode
-   */
-  private createIntensityVariants(
-    baseMode: string,
-    baseModeNumber: number,
-    baseTags: number[],
-    fanSpeedPresets: string[] | null,
-  ): Array<{ label: string; mode: number; modeTags: Array<{ value: number }> }> {
-    const modes: Array<{ label: string; mode: number; modeTags: Array<{ value: number }> }> = [];
-
-    const intensityMap: Record<string, { tag: number; label: string; offset: number }> = {
-      off: { tag: RvcCleanMode.ModeTag.Min, label: 'Off', offset: 4 },
-      min: { tag: RvcCleanMode.ModeTag.Min, label: 'Min', offset: 4 },
-      low: { tag: RvcCleanMode.ModeTag.Quiet, label: 'Quiet', offset: 0 },
-      medium: { tag: RvcCleanMode.ModeTag.Auto, label: 'Auto', offset: 1 },
-      high: { tag: RvcCleanMode.ModeTag.Quick, label: 'Quick', offset: 2 },
-      max: { tag: RvcCleanMode.ModeTag.Max, label: 'Max', offset: 3 },
-      turbo: { tag: RvcCleanMode.ModeTag.Max, label: 'Turbo', offset: 4 },
-    };
-
-    const modeLabel = baseMode === 'vacuum_and_mop' ? 'Vacuum & Mop' : baseMode.charAt(0).toUpperCase() + baseMode.slice(1);
-
-    if (!fanSpeedPresets || fanSpeedPresets.length === 0) {
-      modes.push({
-        label: modeLabel,
-        mode: baseModeNumber,
-        modeTags: [...baseTags.map((tag) => ({ value: tag })), { value: RvcCleanMode.ModeTag.Auto }],
-      });
-      return modes;
-    }
-
-    const usedOffsets = new Set<number>();
-
-    for (const preset of fanSpeedPresets) {
-      const presetLower = preset.toLowerCase();
-      const intensity = intensityMap[presetLower];
-
-      if (intensity && !usedOffsets.has(intensity.offset)) {
-        usedOffsets.add(intensity.offset);
-        modes.push({
-          label: `${modeLabel} (${intensity.label})`,
-          mode: baseModeNumber + intensity.offset,
-          modeTags: [...baseTags.map((tag) => ({ value: tag })), { value: intensity.tag }],
-        });
-      }
-    }
-
-    if (modes.length === 0) {
-      modes.push({
-        label: modeLabel,
-        mode: baseModeNumber,
-        modeTags: [...baseTags.map((tag) => ({ value: tag })), { value: RvcCleanMode.ModeTag.Auto }],
-      });
-    }
-
-    return modes;
-  }
-
-  /**
-   * Create mop mode variants
-   */
-  private createMopVariants(fanSpeedPresets: string[] | null, waterUsagePresets: string[] | null): Array<{ label: string; mode: number; modeTags: Array<{ value: number }> }> {
-    if (!fanSpeedPresets || !waterUsagePresets) {
-      return this.createIntensityVariants('mop', RvcCleanModeValue.MopMin, [RvcCleanMode.ModeTag.Mop], fanSpeedPresets);
-    }
-
-    const modes: Array<{ label: string; mode: number; modeTags: Array<{ value: number }> }> = [];
-    const usedLabels = new Set<string>();
-
-    const mopConfigs: Array<{ fanPreset: string; waterPreset: string; tag: number; label: string; mode: number }> = [
-      { fanPreset: 'medium', waterPreset: 'medium', tag: RvcCleanMode.ModeTag.Auto, label: 'Mop (Auto)', mode: RvcCleanModeValue.MopMin },
-      { fanPreset: 'low', waterPreset: 'low', tag: RvcCleanMode.ModeTag.Quiet, label: 'Mop (Quiet)', mode: RvcCleanModeValue.MopLow },
-      { fanPreset: 'high', waterPreset: 'high', tag: RvcCleanMode.ModeTag.Quick, label: 'Mop (Quick)', mode: RvcCleanModeValue.MopMedium },
-      { fanPreset: 'max', waterPreset: 'high', tag: RvcCleanMode.ModeTag.Max, label: 'Mop (Max)', mode: RvcCleanModeValue.MopHigh },
-    ];
-
-    for (const config of mopConfigs) {
-      const hasFan = fanSpeedPresets.includes(config.fanPreset);
-      const hasWater = waterUsagePresets.includes(config.waterPreset);
-
-      if (hasFan && hasWater && !usedLabels.has(config.label)) {
-        usedLabels.add(config.label);
-        modes.push({
-          label: config.label,
-          mode: config.mode,
-          modeTags: [{ value: RvcCleanMode.ModeTag.Mop }, { value: config.tag }],
-        });
-      }
-    }
-
-    if (modes.length === 0) {
-      return this.createIntensityVariants('mop', RvcCleanModeValue.MopMin, [RvcCleanMode.ModeTag.Mop], fanSpeedPresets);
-    }
-
-    return modes;
-  }
-
-  /**
    * Get fan and water settings from mode number
    */
+  /*
   private getIntensitySettings(mode: number): { fan: string; water: string } {
     let intensityKey: 'auto' | 'quiet' | 'quick' | 'max';
     let defaultFan: string;
@@ -1361,6 +1288,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       water: overrides?.waterUsage || defaultWater,
     };
   }
+  */
 
   /**
    * Get friendly name for a consumable

--- a/src/module.ts
+++ b/src/module.ts
@@ -477,6 +477,37 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         vacuumAndMop: operatingModes?.includes(modeMapping.vacuumAndMop) ? modeMapping.vacuumAndMop : undefined,
       };
 
+      type OperationModeContext = 'vacuum' | 'mop' | 'vacuum_and_mop';
+
+      const config = this.config as {
+        customTags?: Array<{
+          operationMode: Array<OperationModeContext>;
+          fanSpeed: string;
+          waterUsage: string;
+          matterModeTag: number;
+        }>;
+      };
+
+      const customTagMap: Record<OperationModeContext, Record<string, number>> = {
+        vacuum: {},
+        mop: {},
+        vacuum_and_mop: {},
+      };
+      if (config.customTags && config.customTags.length > 0) {
+        for (const customTag of config.customTags) {
+          const modeTag = customTag.matterModeTag;
+          const contexts: Array<OperationModeContext> = customTag.operationMode;
+          for (const ctx of contexts) {
+            if (customTag.fanSpeed) {
+              customTagMap[ctx][customTag.fanSpeed] = modeTag;
+            }
+            if (customTag.waterUsage) {
+              customTagMap[ctx][customTag.waterUsage] = modeTag;
+            }
+          }
+        }
+      }
+
       const presetToTagMap: Record<string, number> = {
         off: RvcCleanMode.ModeTag.Min,
         min: RvcCleanMode.ModeTag.Min,
@@ -486,10 +517,12 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         max: RvcCleanMode.ModeTag.Max,
         turbo: RvcCleanMode.ModeTag.Max,
       };
+
       if (fanSpeedPresets) {
+        const customTags = customTagMap['vacuum'];
         const modeIdBase = RvcCleanModeBase + vacuum.modeMap.size;
         fanSpeedPresets.forEach((preset, index) => {
-          const tag = presetToTagMap[preset] || RvcCleanMode.ModeTag.Auto;
+          const tag = customTags[preset] ?? presetToTagMap[preset] ?? RvcCleanMode.ModeTag.Auto;
           const modeId = modeIdBase + index;
           const label = `Vacuum (${RvcCleanMode.ModeTag[tag]})`;
           supportedCleanModes.push({
@@ -506,10 +539,11 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         });
       }
       if (operatingModes?.includes(modeMapping.mop)) {
+        const customTags = customTagMap['mop'];
         const modeIdBase = RvcCleanModeBase + vacuum.modeMap.size;
         if (waterUsagePresets) {
           waterUsagePresets.forEach((preset, index) => {
-            const tag = presetToTagMap[preset] || RvcCleanMode.ModeTag.Auto;
+            const tag = customTags[preset] ?? presetToTagMap[preset] ?? RvcCleanMode.ModeTag.Auto;
             const modeId = modeIdBase + index;
             const label = `Mop (${RvcCleanMode.ModeTag[tag]})`;
             supportedCleanModes.push({
@@ -538,6 +572,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         }
       }
       if (operatingModes?.includes(modeMapping.vacuumAndMop)) {
+        const customTags = customTagMap['vacuum_and_mop'];
         const modeIdBase = RvcCleanModeBase + vacuum.modeMap.size;
         if (fanSpeedPresets && waterUsagePresets) {
           const nFanSpeeds = fanSpeedPresets.length;
@@ -545,7 +580,8 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
           for (let i = 0; i < Math.max(nFanSpeeds, nWaterLevels); i++) {
             const fanSpeed = fanSpeedPresets[i] ?? fanSpeedPresets[nFanSpeeds - 1];
             const waterUsage = waterUsagePresets[i] ?? waterUsagePresets[nWaterLevels - 1];
-            const tag = presetToTagMap[fanSpeedPresets[i] ?? waterUsagePresets[i]];
+            const preset = fanSpeedPresets[i] ?? waterUsagePresets[i];
+            const tag = customTags[preset] ?? presetToTagMap[preset];
             const modeId = modeIdBase + i;
             const label = `Vacuum & Mop (${RvcCleanMode.ModeTag[tag]})`;
             supportedCleanModes.push({

--- a/src/module.ts
+++ b/src/module.ts
@@ -29,6 +29,7 @@ interface VacuumInstance {
   client: ValetudoClient;
   device: RoboticVacuumCleaner | null;
   pollingInterval: NodeJS.Timeout | null;
+  initialPollTimeout: NodeJS.Timeout | null;
 
   // Per-vacuum state
   capabilities: string[];
@@ -134,6 +135,10 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
     // Stop polling for all vacuums
     for (const vacuum of this.vacuums.values()) {
+      if (vacuum.initialPollTimeout) {
+        clearTimeout(vacuum.initialPollTimeout);
+        vacuum.initialPollTimeout = null;
+      }
       if (vacuum.pollingInterval) {
         clearInterval(vacuum.pollingInterval);
         vacuum.pollingInterval = null;
@@ -288,6 +293,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       client,
       device: null,
       pollingInterval: null,
+      initialPollTimeout: null,
       capabilities: [],
       areaToSegmentMap: new Map(),
       modeMap: new Map(),
@@ -669,7 +675,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
     const staggerOffset = vacuumIndex * 1000; // 1 second stagger per vacuum
     const totalDelay = MIN_INITIAL_DELAY + staggerOffset;
 
-    setTimeout(async () => {
+    vacuum.initialPollTimeout = setTimeout(async () => {
+      vacuum.initialPollTimeout = null;
+
       // Trigger immediate first poll when starting
       try {
         this.log.info(`[${vacuum.name}] Running initial state update...`);
@@ -855,7 +863,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       this.log.info(`  ${name}: ${remaining} ${consumable.remaining.unit}`);
 
       if (exposeAsContactSensors) {
-        const needsReplacement = remaining / matchingProperties.maxValue <= warningThreshold;
+        const needsReplacement = matchingProperties.maxValue <= 0 || remaining / matchingProperties.maxValue <= warningThreshold;
         // Create contact sensor for this consumable
         // Contact sensor: true (closed) = OK, false (open) = needs replacement
         const sensorName = `${vacuum.name} ${name}`;
@@ -1141,7 +1149,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
         const remaining = consumable.remaining.value;
         entry.consumable.remaining.value = remaining;
-        const needsReplacement = remaining / entry.properties.maxValue <= warningThreshold;
+        const needsReplacement = entry.properties.maxValue <= 0 || remaining / entry.properties.maxValue <= warningThreshold;
 
         // Log status change
         if (entry.lastState === undefined || entry.lastState !== needsReplacement) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -126,7 +126,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
     }
 
     if (config.modeMapping) {
-      this.log.warn('DEPRECATED: "modeMapping" config is no longer supported and will be ignored.');
+      this.log.warn('DEPRECATED: "modeMapping" is replaced by "operationModeMapping". Please update your configuration.');
       this.log.warn('  Use "customTags" instead to define per-operation-mode preset mappings.');
       this.log.warn('  See README for the new configuration format.');
     }
@@ -494,13 +494,6 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         vacuum.currentOperationMode = operatingModes[0] as ValetudoOperationMode;
       }
 
-      const valetudoToMatterTags: Record<ValetudoOperationMode, RvcCleanMode.ModeTag[]> = {
-        vacuum: [RvcCleanMode.ModeTag.Vacuum],
-        mop: [RvcCleanMode.ModeTag.Mop],
-        vacuum_and_mop: [RvcCleanMode.ModeTag.Vacuum, RvcCleanMode.ModeTag.Mop],
-        vacuum_then_mop: [RvcCleanMode.ModeTag.VacuumThenMop],
-      };
-
       const defaultPresetToTagMap: Record<string, RvcCleanMode.ModeTag> = {
         min: RvcCleanMode.ModeTag.Min,
         low: RvcCleanMode.ModeTag.Quiet,
@@ -512,13 +505,18 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       };
 
       const config = this.config as {
-        modeOverrides?: Array<{
-          operationMode: ValetudoOperationMode;
+        operationModeMapping?: {
+          vacuum?: ValetudoOperationMode;
+          mop?: ValetudoOperationMode;
+          vacuumAndMop?: ValetudoOperationMode;
+        };
+        intensityOverrides?: Array<{
+          category?: 'vacuum' | 'mop' | 'vacuumAndMop';
           intensity: PresetLevel;
           fanSpeed?: PresetLevel;
           waterUsage?: PresetLevel;
         }>;
-        // Deprecated: old customTags format, kept for backward compatibility
+        // Deprecated: old formats, kept for backward compatibility
         customTags?: Array<{
           operationModes: Array<ValetudoOperationMode>;
           mappings: Array<{
@@ -527,36 +525,75 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
             matterModeTag: RvcCleanMode.ModeTag;
           }>;
         }>;
+        modeOverrides?: Array<{
+          operationMode: ValetudoOperationMode;
+          intensity: PresetLevel;
+          fanSpeed?: PresetLevel;
+          waterUsage?: PresetLevel;
+        }>;
       };
 
-      // Build per-operation-mode tag→preset mappings
-      const tagPresetMap: Record<ValetudoOperationMode, Map<RvcCleanMode.ModeTag, { fanSpeed?: PresetLevel; waterUsage?: PresetLevel }>> = {
+      // Matter categories → Matter tags + Valetudo operation mode
+      // The user can remap which Valetudo operation runs for each Matter category
+      type MatterCategory = 'vacuum' | 'mop' | 'vacuumAndMop';
+      const categoryConfig: Record<MatterCategory, { matterTags: RvcCleanMode.ModeTag[]; valetudoMode: ValetudoOperationMode; label: string }> = {
+        vacuum: {
+          matterTags: [RvcCleanMode.ModeTag.Vacuum],
+          valetudoMode: config.operationModeMapping?.vacuum ?? 'vacuum',
+          label: 'Vacuum',
+        },
+        mop: {
+          matterTags: [RvcCleanMode.ModeTag.Mop],
+          valetudoMode: config.operationModeMapping?.mop ?? 'mop',
+          label: 'Mop',
+        },
+        vacuumAndMop: {
+          matterTags: [RvcCleanMode.ModeTag.Vacuum, RvcCleanMode.ModeTag.Mop],
+          valetudoMode: config.operationModeMapping?.vacuumAndMop ?? 'vacuum_and_mop',
+          label: 'Vacuum And Mop',
+        },
+      };
+
+      // Log any custom operation mode mappings
+      if (config.operationModeMapping) {
+        for (const [cat, catConfig] of Object.entries(categoryConfig)) {
+          const defaultMode = cat === 'vacuumAndMop' ? 'vacuum_and_mop' : cat;
+          if (catConfig.valetudoMode !== defaultMode) {
+            this.log.info(`  operationModeMapping: ${catConfig.label} → Valetudo '${catConfig.valetudoMode}'`);
+          }
+        }
+      }
+
+      // Build per-category intensity mappings
+      // Each category maps Matter intensity tags → { fanSpeed, waterUsage } to send to Valetudo
+      const categoryPresetMap: Record<MatterCategory, Map<RvcCleanMode.ModeTag, { fanSpeed?: PresetLevel; waterUsage?: PresetLevel }>> = {
         vacuum: new Map(),
         mop: new Map(),
-        vacuum_and_mop: new Map(),
-        vacuum_then_mop: new Map(),
+        vacuumAndMop: new Map(),
       };
-      const validOperationModes = new Set<string>(Object.keys(tagPresetMap));
 
-      for (const opMode of operatingModes) {
-        if (!validOperationModes.has(opMode)) {
-          this.log.warn(`  Skipping unknown operation mode from API: "${opMode}"`);
-          continue;
-        }
-        if (opMode === 'vacuum' && vacuum.fanSpeedPresets) {
+      // Determine which categories are available based on the vacuum's capabilities
+      const availableCategories: MatterCategory[] = [];
+      for (const [category, catConfig] of Object.entries(categoryConfig) as Array<[MatterCategory, (typeof categoryConfig)[MatterCategory]]>) {
+        // A category is available if the vacuum supports its mapped Valetudo operation mode
+        if (!operatingModes.includes(catConfig.valetudoMode)) continue;
+        availableCategories.push(category);
+
+        // Build default intensity mappings for this category
+        if (category === 'vacuum' && vacuum.fanSpeedPresets) {
           vacuum.fanSpeedPresets.forEach((preset) => {
-            tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { fanSpeed: preset });
+            categoryPresetMap[category].set(defaultPresetToTagMap[preset], { fanSpeed: preset });
           });
-        } else if (opMode === 'mop' && vacuum.waterUsagePresets) {
+        } else if (category === 'mop' && vacuum.waterUsagePresets) {
           vacuum.waterUsagePresets.forEach((preset) => {
-            tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { waterUsage: preset });
+            categoryPresetMap[category].set(defaultPresetToTagMap[preset], { waterUsage: preset });
           });
-        } else if ((opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop') && vacuum.fanSpeedPresets && vacuum.waterUsagePresets) {
+        } else if (category === 'vacuumAndMop' && vacuum.fanSpeedPresets && vacuum.waterUsagePresets) {
           const nFanSpeeds = vacuum.fanSpeedPresets.length;
           const nWaterLevels = vacuum.waterUsagePresets.length;
           const drivingPreset = nFanSpeeds > nWaterLevels ? vacuum.fanSpeedPresets : vacuum.waterUsagePresets;
           for (let i = 0; i < drivingPreset.length; i++) {
-            tagPresetMap[opMode].set(defaultPresetToTagMap[drivingPreset[i]], {
+            categoryPresetMap[category].set(defaultPresetToTagMap[drivingPreset[i]], {
               fanSpeed: vacuum.fanSpeedPresets[i] ?? vacuum.fanSpeedPresets[nFanSpeeds - 1],
               waterUsage: vacuum.waterUsagePresets[i] ?? vacuum.waterUsagePresets[nWaterLevels - 1],
             });
@@ -564,71 +601,52 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         }
       }
 
-      // Apply mode overrides: user can customize what presets are applied for each mode
-      if (config.modeOverrides && config.modeOverrides.length > 0) {
-        for (const override of config.modeOverrides) {
-          if (!validOperationModes.has(override.operationMode)) {
-            this.log.warn(`  modeOverrides: skipping unknown operation mode "${override.operationMode}"`);
-            continue;
-          }
+      // Apply intensity overrides
+      if (config.intensityOverrides && config.intensityOverrides.length > 0) {
+        for (const override of config.intensityOverrides) {
           const matterTag = defaultPresetToTagMap[override.intensity];
           if (matterTag === undefined) {
-            this.log.warn(`  modeOverrides: skipping unknown intensity "${override.intensity}"`);
+            this.log.warn(`  intensityOverrides: skipping unknown intensity "${override.intensity}"`);
             continue;
           }
-          this.log.info(`  modeOverrides: ${override.operationMode} @ ${override.intensity} → fan=${override.fanSpeed ?? 'default'}, water=${override.waterUsage ?? 'default'}`);
 
-          // Get existing defaults and merge overrides on top
-          const existing = tagPresetMap[override.operationMode].get(matterTag) ?? {};
-          tagPresetMap[override.operationMode].set(matterTag, {
-            fanSpeed: override.fanSpeed ?? existing.fanSpeed,
-            waterUsage: override.waterUsage ?? existing.waterUsage,
-          });
-        }
-      }
-
-      // Backward compatibility: support deprecated customTags format
-      if (config.customTags && config.customTags.length > 0) {
-        this.log.warn('DEPRECATED: "customTags" config is replaced by "modeOverrides". Please update your configuration.');
-        for (const tagGroup of config.customTags) {
-          const selectedModes = tagGroup.operationModes || [];
-          const mappings = tagGroup.mappings || [];
-          for (const opMode of selectedModes) {
-            if (!validOperationModes.has(opMode)) continue;
-            for (const mapping of mappings) {
-              if (typeof mapping.matterModeTag !== 'number') continue;
-              tagPresetMap[opMode].set(mapping.matterModeTag, {
-                fanSpeed: mapping.fanSpeed,
-                waterUsage: mapping.waterUsage,
-              });
-            }
+          // Apply to specific category or all categories
+          const targetCategories: MatterCategory[] = override.category ? [override.category] : availableCategories;
+          for (const cat of targetCategories) {
+            const existing = categoryPresetMap[cat].get(matterTag) ?? {};
+            categoryPresetMap[cat].set(matterTag, {
+              fanSpeed: override.fanSpeed ?? existing.fanSpeed,
+              waterUsage: override.waterUsage ?? existing.waterUsage,
+            });
+            this.log.info(`  intensityOverrides: ${categoryConfig[cat].label} @ ${override.intensity} → fan=${override.fanSpeed ?? 'default'}, water=${override.waterUsage ?? 'default'}`);
           }
         }
       }
 
-      const formatLabel = (opMode: ValetudoOperationMode, intensityTag?: RvcCleanMode.ModeTag): string => {
-        const modeName = opMode
-          .split('_')
-          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-          .join(' ');
-        return intensityTag != undefined ? `${modeName} (${RvcCleanMode.ModeTag[intensityTag]})` : modeName;
-      };
+      // Backward compatibility: support deprecated customTags and modeOverrides formats
+      if (config.customTags && config.customTags.length > 0) {
+        this.log.warn('DEPRECATED: "customTags" config is replaced by "operationModeMapping" and "intensityOverrides". Please update your configuration.');
+      }
+      if (config.modeOverrides && config.modeOverrides.length > 0) {
+        this.log.warn('DEPRECATED: "modeOverrides" config is replaced by "intensityOverrides". Please update your configuration.');
+      }
 
-      // Create modes: one per (operation mode × intensity preset)
+      // Create modes: one per (Matter category × intensity)
       let modeId = RvcCleanModeBase;
-      for (const [opModeStr, tagMap] of Object.entries(tagPresetMap)) {
-        const opMode = opModeStr as ValetudoOperationMode;
-        const opBaseTags = valetudoToMatterTags[opMode];
-        for (const [matterMode, presets] of tagMap) {
-          this.log.debug(`Building mode: ${opMode} × ${RvcCleanMode.ModeTag[matterMode]} → ID ${modeId}`);
+      for (const category of availableCategories) {
+        const catConfig = categoryConfig[category];
+        const tagMap = categoryPresetMap[category];
+        for (const [matterTag, presets] of tagMap) {
+          const label = `${catConfig.label} (${RvcCleanMode.ModeTag[matterTag]})`;
+          this.log.debug(`Building mode: ${label} → ID ${modeId}, valetudo=${catConfig.valetudoMode}`);
           supportedCleanModes.push({
-            label: formatLabel(opMode, matterMode),
+            label,
             mode: modeId,
-            modeTags: [...opBaseTags.map((tag) => ({ value: tag })), { value: matterMode }],
+            modeTags: [...catConfig.matterTags.map((tag) => ({ value: tag })), { value: matterTag }],
           });
           vacuum.modeMap.set(modeId, {
             presetLevel: presets.fanSpeed || presets.waterUsage,
-            setOperationMode: opMode,
+            setOperationMode: catConfig.valetudoMode,
           });
           modeId++;
         }
@@ -639,28 +657,31 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       // in the supported modes list, and Matter.js validates this during initialization before
       // the plugin can intervene.
       // v1.0.7 mode IDs: VacuumMop 5-9 (overlap with new), Mop 31-34, Vacuum 66-70
-      const legacyBaseTags = [{ value: RvcCleanMode.ModeTag.Vacuum }]; // fallback tag for legacy entries
-      const legacyModes: Array<{ id: number; label: string; preset: PresetLevel; opMode: ValetudoOperationMode }> = [
-        { id: 31, label: 'Mop Auto (Legacy)', preset: 'medium', opMode: 'mop' },
-        { id: 32, label: 'Mop Low (Legacy)', preset: 'low', opMode: 'mop' },
-        { id: 33, label: 'Mop Quick (Legacy)', preset: 'high', opMode: 'mop' },
-        { id: 34, label: 'Mop Max (Legacy)', preset: 'max', opMode: 'mop' },
-        { id: 66, label: 'Vacuum Low (Legacy)', preset: 'low', opMode: 'vacuum' },
-        { id: 67, label: 'Vacuum Auto (Legacy)', preset: 'medium', opMode: 'vacuum' },
-        { id: 68, label: 'Vacuum Quick (Legacy)', preset: 'high', opMode: 'vacuum' },
-        { id: 69, label: 'Vacuum Max (Legacy)', preset: 'max', opMode: 'vacuum' },
-        { id: 70, label: 'Vacuum Turbo (Legacy)', preset: 'turbo', opMode: 'vacuum' },
+      const legacyTagMap: Record<string, RvcCleanMode.ModeTag[]> = {
+        vacuum: [RvcCleanMode.ModeTag.Vacuum],
+        mop: [RvcCleanMode.ModeTag.Mop],
+      };
+      const legacyModes: Array<{ id: number; label: string; preset: PresetLevel; category: string; valetudoMode: ValetudoOperationMode }> = [
+        { id: 31, label: 'Mop Auto (Legacy)', preset: 'medium', category: 'mop', valetudoMode: 'mop' },
+        { id: 32, label: 'Mop Low (Legacy)', preset: 'low', category: 'mop', valetudoMode: 'mop' },
+        { id: 33, label: 'Mop Quick (Legacy)', preset: 'high', category: 'mop', valetudoMode: 'mop' },
+        { id: 34, label: 'Mop Max (Legacy)', preset: 'max', category: 'mop', valetudoMode: 'mop' },
+        { id: 66, label: 'Vacuum Low (Legacy)', preset: 'low', category: 'vacuum', valetudoMode: 'vacuum' },
+        { id: 67, label: 'Vacuum Auto (Legacy)', preset: 'medium', category: 'vacuum', valetudoMode: 'vacuum' },
+        { id: 68, label: 'Vacuum Quick (Legacy)', preset: 'high', category: 'vacuum', valetudoMode: 'vacuum' },
+        { id: 69, label: 'Vacuum Max (Legacy)', preset: 'max', category: 'vacuum', valetudoMode: 'vacuum' },
+        { id: 70, label: 'Vacuum Turbo (Legacy)', preset: 'turbo', category: 'vacuum', valetudoMode: 'vacuum' },
       ];
       for (const legacy of legacyModes) {
         // Skip if this ID is already used by a real mode
         if (vacuum.modeMap.has(legacy.id)) continue;
-        const legacyOpTags = valetudoToMatterTags[legacy.opMode] || legacyBaseTags;
+        const legacyOpTags = legacyTagMap[legacy.category] || [RvcCleanMode.ModeTag.Vacuum];
         supportedCleanModes.push({
           label: legacy.label,
           mode: legacy.id,
           modeTags: [...legacyOpTags.map((tag) => ({ value: tag })), { value: defaultPresetToTagMap[legacy.preset] }],
         });
-        vacuum.modeMap.set(legacy.id, { presetLevel: legacy.preset, setOperationMode: legacy.opMode, isLegacy: true });
+        vacuum.modeMap.set(legacy.id, { presetLevel: legacy.preset, setOperationMode: legacy.valetudoMode, isLegacy: true });
       }
 
       if (supportedCleanModes.length === 0) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -33,7 +33,10 @@ interface VacuumInstance {
 
   // Per-vacuum state
   capabilities: string[];
-  modeMap: Map<number, { fanSpeed?: PresetLevel; waterUsage?: PresetLevel; operationMode?: ValetudoOperationMode }>;
+  modeMap: Map<number, { presetLevel: PresetLevel; isLegacy?: boolean }>;
+  currentOperationMode: ValetudoOperationMode;
+  fanSpeedPresets: PresetLevel[] | null;
+  waterUsagePresets: PresetLevel[] | null;
   areaToSegmentMap: Map<number, { id: string; name: string }>;
   selectedSegmentIds: string[];
   selectedRoomNames: string[];
@@ -318,6 +321,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       capabilities: [],
       areaToSegmentMap: new Map(),
       modeMap: new Map(),
+      currentOperationMode: 'vacuum',
+      fanSpeedPresets: null,
+      waterUsagePresets: null,
       selectedSegmentIds: [],
       selectedRoomNames: [],
       consumableMap: new Map(),
@@ -463,43 +469,39 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         });
       }
 
-      // Build clean modes
+      // Build clean modes using shared intensity approach:
+      // One mode per intensity level, shared across all operation modes.
+      // The current operation mode is tracked separately and applied at command time.
+      // This keeps mode count low (max ~7) and mode IDs stable across restarts.
       const supportedCleanModes: Array<{ label: string; mode: number; modeTags: Array<{ value: number }> }> = [];
 
-      let fanSpeedPresets: PresetLevel[] | null = null;
-      let waterUsagePresets: PresetLevel[] | null = null;
       const operatingModes = (vacuum.capabilities.includes('OperationModeControlCapability') ? await vacuum.client.getOperationModePresets() : null) ?? ['vacuum'];
 
       if (vacuum.capabilities.includes('FanSpeedControlCapability')) {
         const presets = await vacuum.client.getFanSpeedPresets();
         if (presets) {
-          fanSpeedPresets = presets.filter((preset) => preset !== 'off');
+          vacuum.fanSpeedPresets = presets.filter((preset) => preset !== 'off');
         }
       }
       if (vacuum.capabilities.includes('WaterUsageControlCapability')) {
         const presets = await vacuum.client.getWaterUsagePresets();
         if (presets) {
-          waterUsagePresets = presets.filter((preset) => preset !== 'off');
+          vacuum.waterUsagePresets = presets.filter((preset) => preset !== 'off');
         }
       }
 
-      const valetudoToMatterTags: Record<ValetudoOperationMode, RvcCleanMode.ModeTag[]> = {
-        vacuum: [RvcCleanMode.ModeTag.Vacuum],
-        mop: [RvcCleanMode.ModeTag.Mop],
-        vacuum_and_mop: [RvcCleanMode.ModeTag.Vacuum, RvcCleanMode.ModeTag.Mop],
-        vacuum_then_mop: [RvcCleanMode.ModeTag.VacuumThenMop],
-      };
+      // Set default operation mode based on what the vacuum supports
+      if (operatingModes.length > 0) {
+        vacuum.currentOperationMode = operatingModes[0] as ValetudoOperationMode;
+      }
 
-      const config = this.config as {
-        customTags?: Array<{
-          operationModes: Array<ValetudoOperationMode>;
-          mappings: Array<{
-            fanSpeed?: PresetLevel;
-            waterUsage?: PresetLevel;
-            matterModeTag: RvcCleanMode.ModeTag;
-          }>;
-        }>;
-      };
+      // Determine which base tags to use based on supported operation modes
+      const hasVacuum = operatingModes.includes('vacuum') || operatingModes.includes('vacuum_and_mop') || operatingModes.includes('vacuum_then_mop');
+      const hasMop = operatingModes.includes('mop') || operatingModes.includes('vacuum_and_mop');
+      const baseTags: Array<{ value: RvcCleanMode.ModeTag }> = [];
+      if (hasVacuum) baseTags.push({ value: RvcCleanMode.ModeTag.Vacuum });
+      if (hasMop) baseTags.push({ value: RvcCleanMode.ModeTag.Mop });
+      if (baseTags.length === 0) baseTags.push({ value: RvcCleanMode.ModeTag.Vacuum }); // fallback
 
       const defaultPresetToTagMap: Record<string, RvcCleanMode.ModeTag> = {
         min: RvcCleanMode.ModeTag.Min,
@@ -511,102 +513,113 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         custom: RvcCleanMode.ModeTag.LowNoise,
       };
 
-      // We create the mapping first then we create the modes
-      const tagPresetMap: Record<ValetudoOperationMode, Map<RvcCleanMode.ModeTag, { fanSpeed?: PresetLevel; waterUsage?: PresetLevel }>> = {
-        vacuum: new Map(),
-        mop: new Map(),
-        vacuum_and_mop: new Map(),
-        vacuum_then_mop: new Map(),
+      const presetToLabelMap: Record<string, string> = {
+        min: 'Min',
+        low: 'Low',
+        medium: 'Auto',
+        high: 'Quick',
+        max: 'Max',
+        turbo: 'Deep Clean',
+        custom: 'Custom',
       };
-      const validOperationModes = new Set<string>(Object.keys(tagPresetMap));
 
-      for (const opMode of operatingModes) {
-        if (!validOperationModes.has(opMode)) {
-          this.log.warn(`  Skipping unknown operation mode from API: "${opMode}"`);
-          continue;
-        }
-        if (opMode === 'vacuum' && fanSpeedPresets) {
-          fanSpeedPresets.forEach((preset) => {
-            tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { fanSpeed: preset });
-          });
-        } else if (opMode === 'mop' && waterUsagePresets) {
-          waterUsagePresets.forEach((preset) => {
-            tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { waterUsage: preset });
-          });
-        } else if ((opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop') && fanSpeedPresets && waterUsagePresets) {
-          const nFanSpeeds = fanSpeedPresets.length;
-          const nWaterLevels = waterUsagePresets.length;
-          const drivingPreset = nFanSpeeds > nWaterLevels ? fanSpeedPresets : waterUsagePresets;
-          for (let i = 0; i < drivingPreset.length; i++) {
-            tagPresetMap[opMode].set(defaultPresetToTagMap[drivingPreset[i]], {
-              fanSpeed: fanSpeedPresets[i] ?? fanSpeedPresets[nFanSpeeds - 1],
-              waterUsage: waterUsagePresets[i] ?? waterUsagePresets[nWaterLevels - 1],
-            });
-          }
-        }
+      // Collect unique preset levels from all sources (fan speed + water usage)
+      const uniquePresets = new Set<PresetLevel>();
+      if (vacuum.fanSpeedPresets) {
+        for (const preset of vacuum.fanSpeedPresets) uniquePresets.add(preset);
+      }
+      if (vacuum.waterUsagePresets) {
+        for (const preset of vacuum.waterUsagePresets) uniquePresets.add(preset);
       }
 
+      // Apply custom tag overrides - custom tags can add additional preset levels
+      const config = this.config as {
+        customTags?: Array<{
+          operationModes: Array<ValetudoOperationMode>;
+          mappings: Array<{
+            fanSpeed?: PresetLevel;
+            waterUsage?: PresetLevel;
+            matterModeTag: RvcCleanMode.ModeTag;
+          }>;
+        }>;
+      };
+
+      const customPresetOverrides = new Map<PresetLevel, RvcCleanMode.ModeTag>();
       if (config.customTags && config.customTags.length > 0) {
         for (const tagGroup of config.customTags) {
-          const selectedModes = tagGroup.operationModes || [];
           const mappings = tagGroup.mappings || [];
-          for (const opMode of selectedModes) {
-            if (!validOperationModes.has(opMode)) {
-              this.log.warn(`  customTags: skipping unknown operation mode "${opMode}"`);
+          for (const mapping of mappings) {
+            if (typeof mapping.matterModeTag !== 'number') {
+              this.log.warn(`  customTags: skipping mapping with invalid matterModeTag: ${JSON.stringify(mapping.matterModeTag)}`);
               continue;
             }
-            for (const mapping of mappings) {
-              if (typeof mapping.matterModeTag !== 'number') {
-                this.log.warn(`  customTags: skipping mapping with invalid matterModeTag: ${JSON.stringify(mapping.matterModeTag)}`);
-                continue;
-              }
-              tagPresetMap[opMode].set(mapping.matterModeTag, {
-                fanSpeed: mapping.fanSpeed,
-                waterUsage: mapping.waterUsage,
-              });
+            // Use the first defined preset level as the key for this override
+            const presetKey = mapping.fanSpeed || mapping.waterUsage;
+            if (presetKey) {
+              uniquePresets.add(presetKey);
+              customPresetOverrides.set(presetKey, mapping.matterModeTag);
             }
           }
         }
       }
-      const formatLabel = (opMode: ValetudoOperationMode, intensityTag?: RvcCleanMode.ModeTag): string => {
-        const modeName = opMode
-          .split('_')
-          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-          .join(' ');
-        return intensityTag != undefined ? `${modeName} (${RvcCleanMode.ModeTag[intensityTag]})` : modeName;
-      };
 
+      // Ordered preset levels for deterministic mode ID assignment
+      const presetOrder: PresetLevel[] = ['min', 'low', 'medium', 'high', 'max', 'turbo', 'custom'];
+      const sortedPresets = presetOrder.filter((p) => uniquePresets.has(p));
+
+      // Create one mode per unique intensity level
       let modeId = RvcCleanModeBase;
-      for (const [opModeStr, tagMap] of Object.entries(tagPresetMap)) {
-        const opMode = opModeStr as ValetudoOperationMode;
-        const baseTags = valetudoToMatterTags[opMode];
-        for (const [matterMode, presets] of tagMap) {
-          this.log.debug(`Building mode for opMode: ${opMode}, matterTag: ${matterMode}, presets: ${JSON.stringify(presets)}`);
-          supportedCleanModes.push({
-            label: formatLabel(opMode, matterMode),
-            mode: modeId,
-            modeTags: [...baseTags.map((tag) => ({ value: tag })), { value: matterMode }],
-          });
-          vacuum.modeMap.set(modeId, {
-            ...presets,
-            operationMode: opMode,
-          });
-          modeId++;
-        }
+      for (const preset of sortedPresets) {
+        const matterTag = customPresetOverrides.get(preset) ?? defaultPresetToTagMap[preset];
+        const label = presetToLabelMap[preset] || preset.charAt(0).toUpperCase() + preset.slice(1);
+
+        this.log.debug(`Building shared intensity mode: ${preset} → ID ${modeId}, tag ${matterTag}, label "${label}"`);
+        supportedCleanModes.push({
+          label,
+          mode: modeId,
+          modeTags: [...baseTags, { value: matterTag }],
+        });
+        vacuum.modeMap.set(modeId, { presetLevel: preset });
+        modeId++;
+      }
+
+      // Legacy v1.0.7 compatibility: add mode IDs that may be persisted from previous versions.
+      // Without these, upgrading from v1.0.7 crashes because the persisted currentMode is not
+      // in the supported modes list, and Matter.js validates this during initialization before
+      // the plugin can intervene. These entries are functionally identical to real modes.
+      // v1.0.7 mode IDs: VacuumMop 5-9 (overlap with new), Mop 31-34, Vacuum 66-70
+      const legacyModes: Array<{ id: number; label: string; preset: PresetLevel }> = [
+        { id: 31, label: 'Mop Auto (Legacy)', preset: 'medium' },
+        { id: 32, label: 'Mop Low (Legacy)', preset: 'low' },
+        { id: 33, label: 'Mop Quick (Legacy)', preset: 'high' },
+        { id: 34, label: 'Mop Max (Legacy)', preset: 'max' },
+        { id: 66, label: 'Vacuum Low (Legacy)', preset: 'low' },
+        { id: 67, label: 'Vacuum Auto (Legacy)', preset: 'medium' },
+        { id: 68, label: 'Vacuum Quick (Legacy)', preset: 'high' },
+        { id: 69, label: 'Vacuum Max (Legacy)', preset: 'max' },
+        { id: 70, label: 'Vacuum Turbo (Legacy)', preset: 'turbo' },
+      ];
+      for (const legacy of legacyModes) {
+        // Skip if this ID is already used by a real mode
+        if (vacuum.modeMap.has(legacy.id)) continue;
+        supportedCleanModes.push({
+          label: legacy.label,
+          mode: legacy.id,
+          modeTags: [...baseTags, { value: defaultPresetToTagMap[legacy.preset] }],
+        });
+        vacuum.modeMap.set(legacy.id, { presetLevel: legacy.preset, isLegacy: true });
       }
 
       if (supportedCleanModes.length === 0) {
         supportedCleanModes.push({
-          label: 'Vacuum',
+          label: 'Auto',
           mode: RvcCleanModeBase,
           modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }, { value: RvcCleanMode.ModeTag.Auto }],
         });
-        vacuum.modeMap.set(RvcCleanModeBase, {
-          fanSpeed: undefined,
-          waterUsage: undefined,
-          operationMode: undefined,
-        });
+        vacuum.modeMap.set(RvcCleanModeBase, { presetLevel: 'medium' });
       }
+      this.log.info(`  Clean modes: ${supportedCleanModes.filter((m) => !vacuum.modeMap.get(m.mode)?.isLegacy).map((m) => `${m.label}(${m.mode})`).join(', ')}`);
+      this.log.debug(`  Legacy compat modes: ${supportedCleanModes.filter((m) => vacuum.modeMap.get(m.mode)?.isLegacy).map((m) => `${m.label}(${m.mode})`).join(', ')}`);
       this.log.debug(`Supported clean modes: ${JSON.stringify(supportedCleanModes)}`);
 
       // Create Matter device
@@ -766,25 +779,40 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
           vacuum.selectedRoomNames = [];
         }
       } else {
-        // Clean mode change
+        // Clean mode change — shared intensity modes apply to the current operation mode
         const modeConfig = vacuum.modeMap.get(request.newMode);
-        const fanSpeed = modeConfig?.fanSpeed;
-        const waterUsage = modeConfig?.waterUsage;
 
         if (modeConfig) {
-          if (modeConfig.operationMode && vacuum.capabilities.includes('OperationModeControlCapability')) {
-            this.log.info(`[${vacuum.name}] Setting mode '${modeConfig.operationMode}'`);
-            await vacuum.client.setOperationMode(modeConfig.operationMode);
+          if (modeConfig.isLegacy) {
+            this.log.info(`[${vacuum.name}] Legacy mode ${request.newMode} selected, mapping to preset '${modeConfig.presetLevel}'`);
           }
 
-          if (fanSpeed && vacuum.capabilities.includes('FanSpeedControlCapability')) {
-            this.log.info(`[${vacuum.name}] Setting fan '${fanSpeed}'`);
-            await vacuum.client.setFanSpeed(fanSpeed);
+          const presetLevel = modeConfig.presetLevel;
+          const opMode = vacuum.currentOperationMode;
+
+          // Set operation mode if the vacuum supports it
+          if (vacuum.capabilities.includes('OperationModeControlCapability')) {
+            this.log.info(`[${vacuum.name}] Setting operation mode '${opMode}'`);
+            await vacuum.client.setOperationMode(opMode);
           }
 
-          if (waterUsage && vacuum.capabilities.includes('WaterUsageControlCapability')) {
-            this.log.info(`[${vacuum.name}] Setting water '${waterUsage}'`);
-            await vacuum.client.setWaterUsage(waterUsage);
+          // Apply fan speed for vacuum-related modes
+          if (vacuum.capabilities.includes('FanSpeedControlCapability') && (opMode === 'vacuum' || opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop')) {
+            // Use the preset directly if available, otherwise fall back to the closest available preset
+            const fanPreset = vacuum.fanSpeedPresets?.includes(presetLevel) ? presetLevel : vacuum.fanSpeedPresets?.[vacuum.fanSpeedPresets.length - 1];
+            if (fanPreset) {
+              this.log.info(`[${vacuum.name}] Setting fan '${fanPreset}'`);
+              await vacuum.client.setFanSpeed(fanPreset);
+            }
+          }
+
+          // Apply water usage for mop-related modes
+          if (vacuum.capabilities.includes('WaterUsageControlCapability') && (opMode === 'mop' || opMode === 'vacuum_and_mop')) {
+            const waterPreset = vacuum.waterUsagePresets?.includes(presetLevel) ? presetLevel : vacuum.waterUsagePresets?.[vacuum.waterUsagePresets.length - 1];
+            if (waterPreset) {
+              this.log.info(`[${vacuum.name}] Setting water '${waterPreset}'`);
+              await vacuum.client.setWaterUsage(waterPreset);
+            }
           }
         }
       }
@@ -965,9 +993,71 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
         this.log.info(`  Initial state: "${statusAttr.value}" (operational: ${operationalState}, run mode: ${runMode})`);
       }
+
+      // Update current operation mode from the fetched attributes
+      this.syncOperationModeFromAttributes(vacuum, attributes);
+
+      // Migrate clean mode: if the persisted currentMode is a legacy mode, switch to
+      // the corresponding real mode. This ensures the next restart won't need the
+      // legacy compatibility entries (they'll eventually be removed in a future version).
+      await this.migrateCleanModeIfNeeded(vacuum);
     } catch (error) {
       this.log.error(`[${vacuum.name}] Error setting initial state: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  /**
+   * Sync the current operation mode from the vacuum state attributes.
+   * Can optionally use pre-fetched attributes to avoid an extra API call.
+   */
+  private syncOperationModeFromAttributes(vacuum: VacuumInstance, attributes: Array<{ __class: string; type?: string; value?: unknown }>): void {
+    if (!vacuum.capabilities.includes('OperationModeControlCapability')) return;
+
+    const opModeAttr = attributes.find((attr) => attr.__class === 'PresetSelectionStateAttribute' && attr.type === 'operation_mode') as
+      | { value: string }
+      | undefined;
+
+    if (opModeAttr?.value) {
+      const newOpMode = opModeAttr.value as ValetudoOperationMode;
+      if (newOpMode !== vacuum.currentOperationMode) {
+        this.log.info(`[${vacuum.name}] Operation mode changed: ${vacuum.currentOperationMode} → ${newOpMode}`);
+        vacuum.currentOperationMode = newOpMode;
+      }
+    }
+  }
+
+  /**
+   * If the persisted currentMode is a legacy ID, migrate it to the corresponding real mode.
+   */
+  private async migrateCleanModeIfNeeded(vacuum: VacuumInstance): Promise<void> {
+    if (!vacuum.device) return;
+
+    try {
+      // Find a real (non-legacy) mode that matches the default preset level
+      const defaultRealModeId = this.findRealModeForPreset(vacuum, 'medium') ?? RvcCleanModeBase;
+
+      // Set currentMode to a known-good real mode. This overwrites any legacy persisted value.
+      await vacuum.device.setAttribute('RvcCleanMode', 'currentMode', defaultRealModeId, this.log);
+      this.log.info(`[${vacuum.name}] Clean mode set to ${defaultRealModeId} (${vacuum.modeMap.get(defaultRealModeId)?.presetLevel ?? 'default'})`);
+    } catch (error) {
+      this.log.warn(`[${vacuum.name}] Failed to migrate clean mode: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Find a real (non-legacy) mode ID for a given preset level.
+   */
+  private findRealModeForPreset(vacuum: VacuumInstance, preset: PresetLevel): number | undefined {
+    for (const [modeId, config] of vacuum.modeMap) {
+      if (config.presetLevel === preset && !config.isLegacy) {
+        return modeId;
+      }
+    }
+    // Fallback: return first non-legacy mode
+    for (const [modeId, config] of vacuum.modeMap) {
+      if (!config.isLegacy) return modeId;
+    }
+    return undefined;
   }
 
   /**
@@ -1048,6 +1138,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
           await new Promise((resolve) => setTimeout(resolve, 200));
         }
       }
+
+      // Update current operation mode from state attributes
+      this.syncOperationModeFromAttributes(vacuum, attributes);
 
       // Clear initial state pending flag after first successful update
       if (vacuum.initialStatePending) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -469,10 +469,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         });
       }
 
-      // Build clean modes using shared intensity approach:
-      // One mode per intensity level, shared across all operation modes.
-      // The current operation mode is tracked separately and applied at command time.
-      // This keeps mode count low (max ~7) and mode IDs stable across restarts.
+      // Build clean modes: one mode per (operation mode × intensity preset).
+      // Each mode is tagged with its operation mode's base tag(s) + intensity tag,
+      // so HomeKit shows separate Vacuum / Mop / Vacuum & Mop categories.
       const supportedCleanModes: Array<{ label: string; mode: number; modeTags: Array<{ value: number }> }> = [];
 
       const operatingModes = (vacuum.capabilities.includes('OperationModeControlCapability') ? await vacuum.client.getOperationModePresets() : null) ?? ['vacuum'];
@@ -495,13 +494,12 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         vacuum.currentOperationMode = operatingModes[0] as ValetudoOperationMode;
       }
 
-      // Determine which base tags to use based on supported operation modes
-      const hasVacuum = operatingModes.includes('vacuum') || operatingModes.includes('vacuum_and_mop') || operatingModes.includes('vacuum_then_mop');
-      const hasMop = operatingModes.includes('mop') || operatingModes.includes('vacuum_and_mop');
-      const baseTags: Array<{ value: RvcCleanMode.ModeTag }> = [];
-      if (hasVacuum) baseTags.push({ value: RvcCleanMode.ModeTag.Vacuum });
-      if (hasMop) baseTags.push({ value: RvcCleanMode.ModeTag.Mop });
-      if (baseTags.length === 0) baseTags.push({ value: RvcCleanMode.ModeTag.Vacuum }); // fallback
+      const valetudoToMatterTags: Record<ValetudoOperationMode, RvcCleanMode.ModeTag[]> = {
+        vacuum: [RvcCleanMode.ModeTag.Vacuum],
+        mop: [RvcCleanMode.ModeTag.Mop],
+        vacuum_and_mop: [RvcCleanMode.ModeTag.Vacuum, RvcCleanMode.ModeTag.Mop],
+        vacuum_then_mop: [RvcCleanMode.ModeTag.VacuumThenMop],
+      };
 
       const defaultPresetToTagMap: Record<string, RvcCleanMode.ModeTag> = {
         min: RvcCleanMode.ModeTag.Min,
@@ -513,26 +511,6 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         custom: RvcCleanMode.ModeTag.LowNoise,
       };
 
-      const presetToLabelMap: Record<string, string> = {
-        min: 'Min',
-        low: 'Low',
-        medium: 'Auto',
-        high: 'Quick',
-        max: 'Max',
-        turbo: 'Deep Clean',
-        custom: 'Custom',
-      };
-
-      // Collect unique preset levels from all sources (fan speed + water usage)
-      const uniquePresets = new Set<PresetLevel>();
-      if (vacuum.fanSpeedPresets) {
-        for (const preset of vacuum.fanSpeedPresets) uniquePresets.add(preset);
-      }
-      if (vacuum.waterUsagePresets) {
-        for (const preset of vacuum.waterUsagePresets) uniquePresets.add(preset);
-      }
-
-      // Apply custom tag overrides - custom tags can add additional preset levels
       const config = this.config as {
         customTags?: Array<{
           operationModes: Array<ValetudoOperationMode>;
@@ -544,112 +522,131 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         }>;
       };
 
-      const customPresetOverrides = new Map<PresetLevel, RvcCleanMode.ModeTag>();
+      // Build per-operation-mode tag→preset mappings
+      const tagPresetMap: Record<ValetudoOperationMode, Map<RvcCleanMode.ModeTag, { fanSpeed?: PresetLevel; waterUsage?: PresetLevel }>> = {
+        vacuum: new Map(),
+        mop: new Map(),
+        vacuum_and_mop: new Map(),
+        vacuum_then_mop: new Map(),
+      };
+      const validOperationModes = new Set<string>(Object.keys(tagPresetMap));
+
+      for (const opMode of operatingModes) {
+        if (!validOperationModes.has(opMode)) {
+          this.log.warn(`  Skipping unknown operation mode from API: "${opMode}"`);
+          continue;
+        }
+        if (opMode === 'vacuum' && vacuum.fanSpeedPresets) {
+          vacuum.fanSpeedPresets.forEach((preset) => {
+            tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { fanSpeed: preset });
+          });
+        } else if (opMode === 'mop' && vacuum.waterUsagePresets) {
+          vacuum.waterUsagePresets.forEach((preset) => {
+            tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { waterUsage: preset });
+          });
+        } else if ((opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop') && vacuum.fanSpeedPresets && vacuum.waterUsagePresets) {
+          const nFanSpeeds = vacuum.fanSpeedPresets.length;
+          const nWaterLevels = vacuum.waterUsagePresets.length;
+          const drivingPreset = nFanSpeeds > nWaterLevels ? vacuum.fanSpeedPresets : vacuum.waterUsagePresets;
+          for (let i = 0; i < drivingPreset.length; i++) {
+            tagPresetMap[opMode].set(defaultPresetToTagMap[drivingPreset[i]], {
+              fanSpeed: vacuum.fanSpeedPresets[i] ?? vacuum.fanSpeedPresets[nFanSpeeds - 1],
+              waterUsage: vacuum.waterUsagePresets[i] ?? vacuum.waterUsagePresets[nWaterLevels - 1],
+            });
+          }
+        }
+      }
+
+      // Apply custom tag overrides
       if (config.customTags && config.customTags.length > 0) {
         for (const tagGroup of config.customTags) {
+          const selectedModes = tagGroup.operationModes || [];
           const mappings = tagGroup.mappings || [];
-          for (const mapping of mappings) {
-            if (typeof mapping.matterModeTag !== 'number') {
-              this.log.warn(`  customTags: skipping mapping with invalid matterModeTag: ${JSON.stringify(mapping.matterModeTag)}`);
+          for (const opMode of selectedModes) {
+            if (!validOperationModes.has(opMode)) {
+              this.log.warn(`  customTags: skipping unknown operation mode "${opMode}"`);
               continue;
             }
-            // Use the first defined preset level as the key for this override
-            const presetKey = mapping.fanSpeed || mapping.waterUsage;
-            if (presetKey) {
-              uniquePresets.add(presetKey);
-              customPresetOverrides.set(presetKey, mapping.matterModeTag);
+            for (const mapping of mappings) {
+              if (typeof mapping.matterModeTag !== 'number') {
+                this.log.warn(`  customTags: skipping mapping with invalid matterModeTag: ${JSON.stringify(mapping.matterModeTag)}`);
+                continue;
+              }
+              tagPresetMap[opMode].set(mapping.matterModeTag, {
+                fanSpeed: mapping.fanSpeed,
+                waterUsage: mapping.waterUsage,
+              });
             }
           }
         }
       }
 
-      // Ordered preset levels for deterministic mode ID assignment
-      const presetOrder: PresetLevel[] = ['min', 'low', 'medium', 'high', 'max', 'turbo', 'custom'];
-      const sortedPresets = presetOrder.filter((p) => uniquePresets.has(p));
+      const formatLabel = (opMode: ValetudoOperationMode, intensityTag?: RvcCleanMode.ModeTag): string => {
+        const modeName = opMode
+          .split('_')
+          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(' ');
+        return intensityTag != undefined ? `${modeName} (${RvcCleanMode.ModeTag[intensityTag]})` : modeName;
+      };
 
-      // Create one mode per unique intensity level
+      // Create modes: one per (operation mode × intensity preset)
       let modeId = RvcCleanModeBase;
-      for (const preset of sortedPresets) {
-        const matterTag = customPresetOverrides.get(preset) ?? defaultPresetToTagMap[preset];
-        const label = presetToLabelMap[preset] || preset.charAt(0).toUpperCase() + preset.slice(1);
-
-        this.log.debug(`Building shared intensity mode: ${preset} → ID ${modeId}, tag ${matterTag}, label "${label}"`);
-        supportedCleanModes.push({
-          label,
-          mode: modeId,
-          modeTags: [...baseTags, { value: matterTag }],
-        });
-        vacuum.modeMap.set(modeId, { presetLevel: preset });
-        modeId++;
-      }
-
-      // Add operation mode selectors so users can switch between vacuum/mop/combo from Matter.
-      // These are separate from intensity modes — selecting one changes the vacuum's operation
-      // mode without changing the intensity level.
-      const valetudoToMatterTags: Record<ValetudoOperationMode, RvcCleanMode.ModeTag[]> = {
-        vacuum: [RvcCleanMode.ModeTag.Vacuum],
-        mop: [RvcCleanMode.ModeTag.Mop],
-        vacuum_and_mop: [RvcCleanMode.ModeTag.Vacuum, RvcCleanMode.ModeTag.Mop],
-        vacuum_then_mop: [RvcCleanMode.ModeTag.VacuumThenMop],
-      };
-      const opModeLabelMap: Record<string, string> = {
-        vacuum: 'Vacuum Mode',
-        mop: 'Mop Mode',
-        vacuum_and_mop: 'Vacuum & Mop Mode',
-        vacuum_then_mop: 'Vacuum Then Mop Mode',
-      };
-      for (const opMode of operatingModes) {
-        const opModeTyped = opMode as ValetudoOperationMode;
-        const opTags = valetudoToMatterTags[opModeTyped];
-        if (!opTags) continue;
-
-        const label = opModeLabelMap[opMode] || opMode;
-        this.log.debug(`Building operation mode: ${opMode} → ID ${modeId}, label "${label}"`);
-        supportedCleanModes.push({
-          label,
-          mode: modeId,
-          modeTags: [...opTags.map((tag) => ({ value: tag })), { value: RvcCleanMode.ModeTag.Auto }],
-        });
-        vacuum.modeMap.set(modeId, { setOperationMode: opModeTyped });
-        modeId++;
+      for (const [opModeStr, tagMap] of Object.entries(tagPresetMap)) {
+        const opMode = opModeStr as ValetudoOperationMode;
+        const opBaseTags = valetudoToMatterTags[opMode];
+        for (const [matterMode, presets] of tagMap) {
+          this.log.debug(`Building mode: ${opMode} × ${RvcCleanMode.ModeTag[matterMode]} → ID ${modeId}`);
+          supportedCleanModes.push({
+            label: formatLabel(opMode, matterMode),
+            mode: modeId,
+            modeTags: [...opBaseTags.map((tag) => ({ value: tag })), { value: matterMode }],
+          });
+          vacuum.modeMap.set(modeId, {
+            presetLevel: presets.fanSpeed || presets.waterUsage,
+            setOperationMode: opMode,
+          });
+          modeId++;
+        }
       }
 
       // Legacy v1.0.7 compatibility: add mode IDs that may be persisted from previous versions.
       // Without these, upgrading from v1.0.7 crashes because the persisted currentMode is not
       // in the supported modes list, and Matter.js validates this during initialization before
-      // the plugin can intervene. These entries are functionally identical to real modes.
+      // the plugin can intervene.
       // v1.0.7 mode IDs: VacuumMop 5-9 (overlap with new), Mop 31-34, Vacuum 66-70
-      const legacyModes: Array<{ id: number; label: string; preset: PresetLevel }> = [
-        { id: 31, label: 'Mop Auto (Legacy)', preset: 'medium' },
-        { id: 32, label: 'Mop Low (Legacy)', preset: 'low' },
-        { id: 33, label: 'Mop Quick (Legacy)', preset: 'high' },
-        { id: 34, label: 'Mop Max (Legacy)', preset: 'max' },
-        { id: 66, label: 'Vacuum Low (Legacy)', preset: 'low' },
-        { id: 67, label: 'Vacuum Auto (Legacy)', preset: 'medium' },
-        { id: 68, label: 'Vacuum Quick (Legacy)', preset: 'high' },
-        { id: 69, label: 'Vacuum Max (Legacy)', preset: 'max' },
-        { id: 70, label: 'Vacuum Turbo (Legacy)', preset: 'turbo' },
+      const legacyBaseTags = [{ value: RvcCleanMode.ModeTag.Vacuum }]; // fallback tag for legacy entries
+      const legacyModes: Array<{ id: number; label: string; preset: PresetLevel; opMode: ValetudoOperationMode }> = [
+        { id: 31, label: 'Mop Auto (Legacy)', preset: 'medium', opMode: 'mop' },
+        { id: 32, label: 'Mop Low (Legacy)', preset: 'low', opMode: 'mop' },
+        { id: 33, label: 'Mop Quick (Legacy)', preset: 'high', opMode: 'mop' },
+        { id: 34, label: 'Mop Max (Legacy)', preset: 'max', opMode: 'mop' },
+        { id: 66, label: 'Vacuum Low (Legacy)', preset: 'low', opMode: 'vacuum' },
+        { id: 67, label: 'Vacuum Auto (Legacy)', preset: 'medium', opMode: 'vacuum' },
+        { id: 68, label: 'Vacuum Quick (Legacy)', preset: 'high', opMode: 'vacuum' },
+        { id: 69, label: 'Vacuum Max (Legacy)', preset: 'max', opMode: 'vacuum' },
+        { id: 70, label: 'Vacuum Turbo (Legacy)', preset: 'turbo', opMode: 'vacuum' },
       ];
       for (const legacy of legacyModes) {
         // Skip if this ID is already used by a real mode
         if (vacuum.modeMap.has(legacy.id)) continue;
+        const legacyOpTags = valetudoToMatterTags[legacy.opMode] || legacyBaseTags;
         supportedCleanModes.push({
           label: legacy.label,
           mode: legacy.id,
-          modeTags: [...baseTags, { value: defaultPresetToTagMap[legacy.preset] }],
+          modeTags: [...legacyOpTags.map((tag) => ({ value: tag })), { value: defaultPresetToTagMap[legacy.preset] }],
         });
-        vacuum.modeMap.set(legacy.id, { presetLevel: legacy.preset, isLegacy: true });
+        vacuum.modeMap.set(legacy.id, { presetLevel: legacy.preset, setOperationMode: legacy.opMode, isLegacy: true });
       }
 
       if (supportedCleanModes.length === 0) {
         supportedCleanModes.push({
-          label: 'Auto',
+          label: 'Vacuum (Auto)',
           mode: RvcCleanModeBase,
           modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }, { value: RvcCleanMode.ModeTag.Auto }],
         });
-        vacuum.modeMap.set(RvcCleanModeBase, { presetLevel: 'medium' });
+        vacuum.modeMap.set(RvcCleanModeBase, { presetLevel: 'medium', setOperationMode: 'vacuum' });
       }
-      const realModes = supportedCleanModes.filter((m) => { const c = vacuum.modeMap.get(m.mode); return !c?.isLegacy; });
+      const realModes = supportedCleanModes.filter((m) => !vacuum.modeMap.get(m.mode)?.isLegacy);
       this.log.info(`  Clean modes (${realModes.length}): ${realModes.map((m) => `${m.label}(${m.mode})`).join(', ')}`);
       this.log.debug(`  Legacy compat modes: ${supportedCleanModes.filter((m) => vacuum.modeMap.get(m.mode)?.isLegacy).map((m) => `${m.label}(${m.mode})`).join(', ')}`);
       this.log.debug(`Supported clean modes: ${JSON.stringify(supportedCleanModes)}`);
@@ -811,34 +808,27 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
           vacuum.selectedRoomNames = [];
         }
       } else {
-        // Clean mode change
+        // Clean mode change — each mode specifies an operation mode + intensity preset
         const modeConfig = vacuum.modeMap.get(request.newMode);
 
         if (modeConfig) {
           if (modeConfig.isLegacy) {
-            this.log.info(`[${vacuum.name}] Legacy mode ${request.newMode} selected, mapping to preset '${modeConfig.presetLevel}'`);
+            this.log.info(`[${vacuum.name}] Legacy mode ${request.newMode} mapped to ${modeConfig.setOperationMode}/${modeConfig.presetLevel}`);
           }
 
-          if (modeConfig.setOperationMode) {
-            // Operation mode selector — switch the vacuum's operation mode
-            const newOpMode = modeConfig.setOperationMode;
-            this.log.info(`[${vacuum.name}] Switching operation mode to '${newOpMode}'`);
-            vacuum.currentOperationMode = newOpMode;
+          const opMode = modeConfig.setOperationMode ?? vacuum.currentOperationMode;
+          const presetLevel = modeConfig.presetLevel;
 
-            if (vacuum.capabilities.includes('OperationModeControlCapability')) {
-              await vacuum.client.setOperationMode(newOpMode);
-            }
-          } else if (modeConfig.presetLevel) {
-            // Intensity mode — apply preset to the current operation mode
-            const presetLevel = modeConfig.presetLevel;
-            const opMode = vacuum.currentOperationMode;
+          // Update tracked operation mode
+          vacuum.currentOperationMode = opMode;
 
-            // Set operation mode if the vacuum supports it
-            if (vacuum.capabilities.includes('OperationModeControlCapability')) {
-              this.log.info(`[${vacuum.name}] Setting operation mode '${opMode}'`);
-              await vacuum.client.setOperationMode(opMode);
-            }
+          // Set operation mode if the vacuum supports it
+          if (vacuum.capabilities.includes('OperationModeControlCapability')) {
+            this.log.info(`[${vacuum.name}] Setting operation mode '${opMode}'`);
+            await vacuum.client.setOperationMode(opMode);
+          }
 
+          if (presetLevel) {
             // Apply fan speed for vacuum-related modes
             if (vacuum.capabilities.includes('FanSpeedControlCapability') && (opMode === 'vacuum' || opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop')) {
               const fanPreset = vacuum.fanSpeedPresets?.includes(presetLevel) ? presetLevel : vacuum.fanSpeedPresets?.[vacuum.fanSpeedPresets.length - 1];

--- a/src/module.ts
+++ b/src/module.ts
@@ -873,7 +873,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
     // Change mode command (handles both run mode and clean mode)
     vacuum.device.addCommandHandler('changeToMode', async (data: { request: Record<string, unknown> }) => {
-      this.log.info(`[${vacuum.name}] changeToMode called: ${JSON.stringify(data)}`);
+      this.log.info(`[${vacuum.name}] changeToMode called: ${JSON.stringify(data, (_, v) => typeof v === 'bigint' ? Number(v) : v)}`);
 
       const request = data.request as { newMode: number };
       const isRunMode = request.newMode >= 1 && request.newMode <= 3;
@@ -966,7 +966,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
     // Select areas command
     vacuum.device.addCommandHandler('selectAreas', async (data: { request: Record<string, unknown> }) => {
-      this.log.info(`[${vacuum.name}] selectAreas called: ${JSON.stringify(data)}`);
+      this.log.info(`[${vacuum.name}] selectAreas called: ${JSON.stringify(data, (_, v) => typeof v === 'bigint' ? Number(v) : v)}`);
 
       const request = data.request as { newAreas?: number[] };
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -480,12 +480,14 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         const presets = await vacuum.client.getFanSpeedPresets();
         if (presets) {
           vacuum.fanSpeedPresets = presets.filter((preset) => preset !== 'off');
+          this.log.info(`  Fan speed presets: ${vacuum.fanSpeedPresets.join(', ')}`);
         }
       }
       if (vacuum.capabilities.includes('WaterUsageControlCapability')) {
         const presets = await vacuum.client.getWaterUsagePresets();
         if (presets) {
           vacuum.waterUsagePresets = presets.filter((preset) => preset !== 'off');
+          this.log.info(`  Water usage presets: ${vacuum.waterUsagePresets.join(', ')}`);
         }
       }
 
@@ -622,6 +624,14 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
           if (matterTag === undefined) {
             this.log.warn(`  intensityOverrides: skipping unknown intensity "${override.intensity}". Valid values: ${Object.keys(matterLabelToTag).join(', ')}`);
             continue;
+          }
+
+          // Validate presets against what the vacuum actually supports
+          if (override.fanSpeed && vacuum.fanSpeedPresets && !vacuum.fanSpeedPresets.includes(override.fanSpeed)) {
+            this.log.warn(`  intensityOverrides: fan speed '${override.fanSpeed}' is not supported by this vacuum. Available: ${vacuum.fanSpeedPresets.join(', ')}`);
+          }
+          if (override.waterUsage && vacuum.waterUsagePresets && !vacuum.waterUsagePresets.includes(override.waterUsage)) {
+            this.log.warn(`  intensityOverrides: water usage '${override.waterUsage}' is not supported by this vacuum. Available: ${vacuum.waterUsagePresets.join(', ')}`);
           }
 
           // Apply to specific category or all categories
@@ -912,6 +922,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
             if (vacuum.capabilities.includes('FanSpeedControlCapability') && (opMode === 'vacuum' || opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop')) {
               const fanPreset = vacuum.fanSpeedPresets?.includes(presetLevel) ? presetLevel : vacuum.fanSpeedPresets?.[vacuum.fanSpeedPresets.length - 1];
               if (fanPreset) {
+                if (fanPreset !== presetLevel) {
+                  this.log.warn(`[${vacuum.name}] Fan speed '${presetLevel}' not supported, falling back to '${fanPreset}'. Available: ${vacuum.fanSpeedPresets?.join(', ')}`);
+                }
                 this.log.info(`[${vacuum.name}] Setting fan '${fanPreset}'`);
                 await vacuum.client.setFanSpeed(fanPreset);
               }
@@ -921,6 +934,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
             if (vacuum.capabilities.includes('WaterUsageControlCapability') && (opMode === 'mop' || opMode === 'vacuum_and_mop')) {
               const waterPreset = vacuum.waterUsagePresets?.includes(presetLevel) ? presetLevel : vacuum.waterUsagePresets?.[vacuum.waterUsagePresets.length - 1];
               if (waterPreset) {
+                if (waterPreset !== presetLevel) {
+                  this.log.warn(`[${vacuum.name}] Water usage '${presetLevel}' not supported, falling back to '${waterPreset}'. Available: ${vacuum.waterUsagePresets?.join(', ')}`);
+                }
                 this.log.info(`[${vacuum.name}] Setting water '${waterPreset}'`);
                 await vacuum.client.setWaterUsage(waterPreset);
               }

--- a/src/module.ts
+++ b/src/module.ts
@@ -103,9 +103,30 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
   override async onStart(reason?: string) {
     this.log.info(`onStart called with reason: ${reason ?? 'none'}`);
 
+    this.checkDeprecatedConfig();
+
     await this.ready;
     await this.clearSelect();
     await this.discoverDevices();
+  }
+
+  /**
+   * Warn users about deprecated config keys from pre-v1.0.8 versions
+   */
+  private checkDeprecatedConfig(): void {
+    const config = this.config as Record<string, unknown>;
+
+    if (config.intensityPresets) {
+      this.log.warn('DEPRECATED: "intensityPresets" config is no longer supported and will be ignored.');
+      this.log.warn('  Use "customTags" instead to map fan speed / water usage presets to Matter mode tags.');
+      this.log.warn('  See README for the new configuration format.');
+    }
+
+    if (config.modeMapping) {
+      this.log.warn('DEPRECATED: "modeMapping" config is no longer supported and will be ignored.');
+      this.log.warn('  Use "customTags" instead to define per-operation-mode preset mappings.');
+      this.log.warn('  See README for the new configuration format.');
+    }
   }
 
   override async onConfigure() {
@@ -826,6 +847,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         enabled?: boolean;
         exposeAsContactSensors?: boolean;
         warningThreshold?: number;
+        maxLifetimes?: Record<string, number>;
       };
     };
 
@@ -849,6 +871,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
     const exposeAsContactSensors = config.consumables?.exposeAsContactSensors === true;
 
     const warningThreshold = (config.consumables?.warningThreshold ?? 10) / 100;
+    const maxLifetimes = config.consumables?.maxLifetimes;
     const consumableProperties = await vacuum.client.getConsumablesProperties();
 
     for (const consumable of consumables) {
@@ -857,6 +880,11 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       if (!matchingProperties) {
         this.log.info(`No properties found for consumable ${name}`);
         continue;
+      }
+      const effectiveMaxValue = this.getConsumableMaxValue(consumable, matchingProperties.maxValue, maxLifetimes);
+      if (effectiveMaxValue !== matchingProperties.maxValue) {
+        this.log.info(`  ${name}: using configured maxLifetime (${effectiveMaxValue}) instead of API value (${matchingProperties.maxValue})`);
+        matchingProperties.maxValue = effectiveMaxValue;
       }
       const remaining = consumable.remaining.value;
 
@@ -1232,6 +1260,32 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
     }
 
     return typeMap[key] || `${consumable.type} ${consumable.subType}`;
+  }
+
+  /**
+   * Resolve the effective maxValue for a consumable, applying user overrides from maxLifetimes config
+   */
+  private getConsumableMaxValue(
+    consumable: { type: string; subType: string },
+    apiMaxValue: number,
+    maxLifetimes?: Record<string, number>,
+  ): number {
+    if (!maxLifetimes) return apiMaxValue;
+
+    // Map consumable type+subType to config key
+    const configKeyMap: Record<string, string> = {
+      'brush-main': 'mainBrush',
+      'brush-side_right': 'sideBrush',
+      'brush-side_left': 'sideBrush',
+      'filter-main': 'dustFilter',
+      'cleaning-sensor': 'sensor',
+      'mop-main': 'mop',
+    };
+    const configKey = configKeyMap[`${consumable.type}-${consumable.subType}`];
+    if (configKey && maxLifetimes[configKey] !== undefined) {
+      return maxLifetimes[configKey];
+    }
+    return apiMaxValue;
   }
 
   /**

--- a/src/module.ts
+++ b/src/module.ts
@@ -805,7 +805,6 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       consumables?: {
         enabled?: boolean;
         exposeAsContactSensors?: boolean;
-        maxLifetimes?: Record<string, number>;
         warningThreshold?: number;
       };
     };
@@ -1110,7 +1109,6 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
     const config = this.config as {
       consumables?: {
-        maxLifetimes?: Record<string, number>;
         warningThreshold?: number;
       };
     };
@@ -1214,36 +1212,6 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
     }
 
     return typeMap[key] || `${consumable.type} ${consumable.subType}`;
-  }
-
-  /**
-   * Get maximum lifetime for a consumable type from config
-   */
-  private getMaxLifetime(consumable: ValetudoConsumable, maxLifetimes: Record<string, number>): number {
-    // Special handling for percentage-based consumables (detergent, etc.)
-    // These have remaining values in 0-100 range representing percentage
-    if (consumable.remaining.value <= 100 && consumable.remaining.value >= 0) {
-      // Check if this looks like a percentage (detergent typically reports 0-100)
-      const isPercentage = consumable.type === 'consumable' || consumable.subType.includes('detergent') || consumable.subType.includes('dock');
-      if (isPercentage) {
-        return 100; // Max is 100%
-      }
-    }
-
-    let key: string;
-    if (consumable.type === 'brush' && consumable.subType === 'main') {
-      key = 'mainBrush';
-    } else if (consumable.type === 'brush' && (consumable.subType === 'side_right' || consumable.subType === 'side_left')) {
-      key = 'sideBrush';
-    } else if (consumable.type === 'filter' && consumable.subType === 'main') {
-      key = 'dustFilter';
-    } else if (consumable.type === 'cleaning' && consumable.subType === 'sensor') {
-      key = 'sensor';
-    } else {
-      return 10000;
-    }
-
-    return maxLifetimes[key] || 10000;
   }
 
   /**

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,13 +10,13 @@
 import { MatterbridgeDynamicPlatform, PlatformConfig, MatterbridgeEndpoint, contactSensor } from 'matterbridge';
 import { RoboticVacuumCleaner } from 'matterbridge/devices';
 import { AnsiLogger, LogLevel } from 'matterbridge/logger';
-import { RvcCleanMode, RvcRunMode } from 'matterbridge/matter/clusters';
+import { RvcCleanMode, RvcOperationalState, RvcRunMode } from 'matterbridge/matter/clusters';
 
 // Derive PlatformMatterbridge type from the parent class constructor to avoid
 // import resolution issues across different npm dependency tree layouts.
 type PlatformMatterbridge = ConstructorParameters<typeof MatterbridgeDynamicPlatform>[0];
 
-import { ValetudoClient, BatteryStateAttribute, ValetudoConsumable, CachedMapLayers } from './valetudo-client.js';
+import { BatteryStateAttribute, CachedMapLayers, ConsumableProperties, PresetLevel, ValetudoClient, ValetudoConsumable, ValetudoOperationMode } from './valetudo-client.js';
 import { ValetudoDiscovery } from './valetudo-discovery.js';
 
 /**
@@ -33,11 +33,11 @@ interface VacuumInstance {
   // Per-vacuum state
   capabilities: string[];
   operationModes: string[];
-  modeMap: Map<number, { fanSpeed?: string; waterUsage?: string; operationMode?: string }>;
+  modeMap: Map<number, { fanSpeed?: PresetLevel; waterUsage?: PresetLevel; operationMode?: ValetudoOperationMode }>;
   areaToSegmentMap: Map<number, { id: string; name: string }>;
   selectedSegmentIds: string[];
   selectedRoomNames: string[];
-  consumableMap: Map<string, { endpoint?: MatterbridgeEndpoint; consumable: ValetudoConsumable; lastState?: boolean }>;
+  consumableMap: Map<string, { endpoint?: MatterbridgeEndpoint; consumable: ValetudoConsumable; properties: ConsumableProperties; lastState?: boolean }>;
   mapLayersCache: CachedMapLayers | null;
   mapCacheValidUntil: number;
   lastCurrentArea: number | null;
@@ -66,19 +66,6 @@ const enum RvcRunModeValue {
 }
 
 const RvcCleanModeBase = 5;
-
-/**
- * Matter Operational State enum values
- */
-const enum OperationalStateValue {
-  Stopped = 0x00,
-  Running = 0x01,
-  Paused = 0x02,
-  Error = 0x03,
-  SeekingCharger = 0x40,
-  Charging = 0x41,
-  Docked = 0x42,
-}
 
 /**
  * Plugin initialization function - standard Matterbridge plugin interface.
@@ -454,9 +441,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       // Build clean modes
       const supportedCleanModes: Array<{ label: string; mode: number; modeTags: Array<{ value: number }> }> = [];
 
-      let fanSpeedPresets: string[] | null = null;
-      let waterUsagePresets: string[] | null = null;
-      const operatingModes = vacuum.capabilities.includes('OperationModeControlCapability') ? await vacuum.client.getOperationModePresets() : null;
+      let fanSpeedPresets: PresetLevel[] | null = null;
+      let waterUsagePresets: PresetLevel[] | null = null;
+      const operatingModes = (vacuum.capabilities.includes('OperationModeControlCapability') ? await vacuum.client.getOperationModePresets() : null) ?? ['vacuum'];
 
       if (vacuum.capabilities.includes('FanSpeedControlCapability')) {
         const presets = await vacuum.client.getFanSpeedPresets();
@@ -470,131 +457,102 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
           waterUsagePresets = presets.filter((preset) => preset !== 'off');
         }
       }
-      const modeMapping = this.getModeMapping();
-      const operationModeMap: Record<string, string | undefined> = {
-        vacuum: operatingModes?.includes(modeMapping.vacuum) ? modeMapping.vacuum : undefined,
-        mop: operatingModes?.includes(modeMapping.mop) ? modeMapping.mop : undefined,
-        vacuumAndMop: operatingModes?.includes(modeMapping.vacuumAndMop) ? modeMapping.vacuumAndMop : undefined,
-      };
 
-      type OperationModeContext = 'vacuum' | 'mop' | 'vacuum_and_mop';
+      const valetudoToMatterTags: Record<ValetudoOperationMode, RvcCleanMode.ModeTag[]> = {
+        vacuum: [RvcCleanMode.ModeTag.Vacuum],
+        mop: [RvcCleanMode.ModeTag.Mop],
+        vacuum_and_mop: [RvcCleanMode.ModeTag.Vacuum, RvcCleanMode.ModeTag.Mop],
+        vacuum_then_mop: [RvcCleanMode.ModeTag.VacuumThenMop],
+      };
 
       const config = this.config as {
         customTags?: Array<{
-          operationMode: Array<OperationModeContext>;
-          fanSpeed: string;
-          waterUsage: string;
-          matterModeTag: number;
+          operationModes: Array<ValetudoOperationMode>;
+          mappings: Array<{
+            fanSpeed?: PresetLevel;
+            waterUsage?: PresetLevel;
+            matterModeTag: RvcCleanMode.ModeTag;
+          }>;
         }>;
       };
 
-      const customTagMap: Record<OperationModeContext, Record<string, number>> = {
-        vacuum: {},
-        mop: {},
-        vacuum_and_mop: {},
-      };
-      if (config.customTags && config.customTags.length > 0) {
-        for (const customTag of config.customTags) {
-          const modeTag = customTag.matterModeTag;
-          const contexts: Array<OperationModeContext> = customTag.operationMode;
-          for (const ctx of contexts) {
-            if (customTag.fanSpeed) {
-              customTagMap[ctx][customTag.fanSpeed] = modeTag;
-            }
-            if (customTag.waterUsage) {
-              customTagMap[ctx][customTag.waterUsage] = modeTag;
-            }
-          }
-        }
-      }
-
-      const presetToTagMap: Record<string, number> = {
-        off: RvcCleanMode.ModeTag.Min,
+      const defaultPresetToTagMap: Record<string, RvcCleanMode.ModeTag> = {
         min: RvcCleanMode.ModeTag.Min,
         low: RvcCleanMode.ModeTag.Quiet,
         medium: RvcCleanMode.ModeTag.Auto,
         high: RvcCleanMode.ModeTag.Quick,
         max: RvcCleanMode.ModeTag.Max,
-        turbo: RvcCleanMode.ModeTag.Max,
+        turbo: RvcCleanMode.ModeTag.DeepClean,
+        custom: RvcCleanMode.ModeTag.LowNoise,
       };
 
-      if (fanSpeedPresets) {
-        const customTags = customTagMap['vacuum'];
-        const modeIdBase = RvcCleanModeBase + vacuum.modeMap.size;
-        fanSpeedPresets.forEach((preset, index) => {
-          const tag = customTags[preset] ?? presetToTagMap[preset] ?? RvcCleanMode.ModeTag.Auto;
-          const modeId = modeIdBase + index;
-          const label = `Vacuum (${RvcCleanMode.ModeTag[tag]})`;
-          supportedCleanModes.push({
-            label: label,
-            mode: modeId,
-            modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }, { value: tag }],
+      // We create the mapping first then we create the modes
+      const tagPresetMap: Record<ValetudoOperationMode, Map<RvcCleanMode.ModeTag, { fanSpeed?: PresetLevel; waterUsage?: PresetLevel }>> = {
+        vacuum: new Map(),
+        mop: new Map(),
+        vacuum_and_mop: new Map(),
+        vacuum_then_mop: new Map(),
+      };
+      for (const opMode of operatingModes) {
+        if (opMode === 'vacuum' && fanSpeedPresets) {
+          fanSpeedPresets.forEach((preset, _) => {
+            tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { fanSpeed: preset });
           });
-
-          vacuum.modeMap.set(modeId, {
-            fanSpeed: preset,
-            waterUsage: undefined,
-            operationMode: operationModeMap['vacuum'],
+        } else if (opMode === 'mop' && waterUsagePresets) {
+          waterUsagePresets.forEach((preset, _) => {
+            tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { waterUsage: preset });
           });
-        });
-      }
-      if (operatingModes?.includes(modeMapping.mop)) {
-        const customTags = customTagMap['mop'];
-        const modeIdBase = RvcCleanModeBase + vacuum.modeMap.size;
-        if (waterUsagePresets) {
-          waterUsagePresets.forEach((preset, index) => {
-            const tag = customTags[preset] ?? presetToTagMap[preset] ?? RvcCleanMode.ModeTag.Auto;
-            const modeId = modeIdBase + index;
-            const label = `Mop (${RvcCleanMode.ModeTag[tag]})`;
-            supportedCleanModes.push({
-              label: label,
-              mode: modeId,
-              modeTags: [{ value: RvcCleanMode.ModeTag.Mop }, { value: tag }],
-            });
-
-            vacuum.modeMap.set(modeId, {
-              fanSpeed: undefined,
-              waterUsage: preset,
-              operationMode: operationModeMap['mop'],
-            });
-          });
-        } else {
-          supportedCleanModes.push({
-            label: `Mop (Auto)`,
-            mode: modeIdBase,
-            modeTags: [{ value: RvcCleanMode.ModeTag.Mop }, { value: RvcCleanMode.ModeTag.Auto }],
-          });
-          vacuum.modeMap.set(modeIdBase, {
-            fanSpeed: undefined,
-            waterUsage: 'med',
-            operationMode: operationModeMap['mop'],
-          });
-        }
-      }
-      if (operatingModes?.includes(modeMapping.vacuumAndMop)) {
-        const customTags = customTagMap['vacuum_and_mop'];
-        const modeIdBase = RvcCleanModeBase + vacuum.modeMap.size;
-        if (fanSpeedPresets && waterUsagePresets) {
+        } else if ((opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop') && fanSpeedPresets && waterUsagePresets) {
           const nFanSpeeds = fanSpeedPresets.length;
           const nWaterLevels = waterUsagePresets.length;
-          for (let i = 0; i < Math.max(nFanSpeeds, nWaterLevels); i++) {
-            const fanSpeed = fanSpeedPresets[i] ?? fanSpeedPresets[nFanSpeeds - 1];
-            const waterUsage = waterUsagePresets[i] ?? waterUsagePresets[nWaterLevels - 1];
-            const preset = fanSpeedPresets[i] ?? waterUsagePresets[i];
-            const tag = customTags[preset] ?? presetToTagMap[preset];
-            const modeId = modeIdBase + i;
-            const label = `Vacuum & Mop (${RvcCleanMode.ModeTag[tag]})`;
-            supportedCleanModes.push({
-              label: label,
-              mode: modeId,
-              modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }, { value: RvcCleanMode.ModeTag.Mop }, { value: tag }],
-            });
-            vacuum.modeMap.set(modeId, {
-              fanSpeed: fanSpeed,
-              waterUsage: waterUsage,
-              operationMode: operationModeMap['vacuumAndMop'],
+          const drivingPreset = nFanSpeeds > nWaterLevels ? fanSpeedPresets : waterUsagePresets;
+          for (let i = 0; i < drivingPreset.length; i++) {
+            tagPresetMap[opMode].set(defaultPresetToTagMap[drivingPreset[i]], {
+              fanSpeed: fanSpeedPresets[i] ?? fanSpeedPresets[nFanSpeeds - 1],
+              waterUsage: waterUsagePresets[i] ?? waterUsagePresets[nWaterLevels - 1],
             });
           }
+        }
+      }
+
+      if (config.customTags && config.customTags.length > 0) {
+        for (const tagGroup of config.customTags) {
+          const selectedModes = tagGroup.operationModes || [];
+          const mappings = tagGroup.mappings || [];
+          for (const opMode of selectedModes) {
+            for (const mapping of mappings) {
+              tagPresetMap[opMode].set(mapping.matterModeTag, {
+                fanSpeed: mapping.fanSpeed,
+                waterUsage: mapping.waterUsage,
+              });
+            }
+          }
+        }
+      }
+      const formatLabel = (opMode: ValetudoOperationMode, intensityTag?: RvcCleanMode.ModeTag): string => {
+        const modeName = opMode
+          .split('_')
+          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(' ');
+        return intensityTag != undefined ? `${modeName} (${RvcCleanMode.ModeTag[intensityTag]})` : modeName;
+      };
+
+      let modeId = RvcCleanModeBase;
+      for (const [opModeStr, tagMap] of Object.entries(tagPresetMap)) {
+        const opMode = opModeStr as ValetudoOperationMode;
+        const baseTags = valetudoToMatterTags[opMode];
+        for (const [matterMode, presets] of tagMap) {
+          this.log.debug(`Building mode for opMode: ${opMode}, matterTag: ${matterMode}, presets: ${JSON.stringify(presets)}`);
+          supportedCleanModes.push({
+            label: formatLabel(opMode, matterMode),
+            mode: modeId,
+            modeTags: [...baseTags.map((tag) => ({ value: tag })), { value: matterMode }],
+          });
+          vacuum.modeMap.set(modeId, {
+            ...presets,
+            operationMode: opMode,
+          });
+          modeId++;
         }
       }
 
@@ -773,7 +731,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         const waterUsage = modeConfig?.waterUsage;
 
         if (modeConfig) {
-          if (modeConfig.operationMode) {
+          if (modeConfig.operationMode && vacuum.capabilities.includes('OperationModeControlCapability')) {
             this.log.info(`[${vacuum.name}] Setting mode '${modeConfig.operationMode}'`);
             await vacuum.client.setOperationMode(modeConfig.operationMode);
           }
@@ -840,18 +798,6 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
   }
 
   /**
-   * Get the configured mode mapping with defaults
-   */
-  private getModeMapping(): { vacuum: string; mop: string; vacuumAndMop: string } {
-    const config = this.config as { modeMapping?: { vacuum?: string; mop?: string; vacuumAndMop?: string } };
-    return {
-      vacuum: config.modeMapping?.vacuum || 'vacuum',
-      mop: config.modeMapping?.mop || 'mop',
-      vacuumAndMop: config.modeMapping?.vacuumAndMop || 'vacuum_and_mop',
-    };
-  }
-
-  /**
    * Set up consumables for a specific vacuum
    */
   private async setupConsumablesForVacuum(vacuum: VacuumInstance): Promise<void> {
@@ -881,28 +827,24 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
     }
 
     this.log.info(`[${vacuum.name}] Found ${consumables.length} consumables`);
-
-    const maxLifetimes = config.consumables?.maxLifetimes || {
-      mainBrush: 18000,
-      sideBrush: 12000,
-      dustFilter: 9000,
-      sensor: 1800,
-    };
-
     const exposeAsContactSensors = config.consumables?.exposeAsContactSensors === true;
 
-    const warningThreshold = config.consumables?.warningThreshold ?? 10;
+    const warningThreshold = (config.consumables?.warningThreshold ?? 10) / 100;
+    const consumableProperties = await vacuum.client.getConsumablesProperties();
 
     for (const consumable of consumables) {
       const name = this.getConsumableName(consumable);
-      const maxLifetime = this.getMaxLifetime(consumable, maxLifetimes);
-      const remainingMinutes = consumable.remaining.value;
-      const lifePercent = Math.round((remainingMinutes / maxLifetime) * 100);
-      const needsReplacement = lifePercent <= warningThreshold;
+      const matchingProperties = consumableProperties?.find((prop) => prop.type === consumable.type && prop.subType === consumable.subType);
+      if (!matchingProperties) {
+        this.log.info(`No properties fround for consumable ${name}`);
+        continue;
+      }
+      const remaining = consumable.remaining.value;
 
-      this.log.info(`  ${name}: ${remainingMinutes}min (${lifePercent}%)`);
+      this.log.info(`  ${name}: ${remaining} ${consumable.remaining.unit}`);
 
       if (exposeAsContactSensors) {
+        const needsReplacement = remaining / matchingProperties.maxValue <= warningThreshold;
         // Create contact sensor for this consumable
         // Contact sensor: true (closed) = OK, false (open) = needs replacement
         const sensorName = `${vacuum.name} ${name}`;
@@ -916,10 +858,10 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
         await this.registerDevice(sensor);
 
-        vacuum.consumableMap.set(name, { endpoint: sensor, consumable, lastState: needsReplacement });
+        vacuum.consumableMap.set(name, { endpoint: sensor, consumable: consumable, properties: matchingProperties, lastState: needsReplacement });
         this.log.info(`  Contact sensor registered: ${sensorName} (${needsReplacement ? 'OPEN - needs replacement' : 'CLOSED - OK'})`);
       } else {
-        vacuum.consumableMap.set(name, { consumable });
+        vacuum.consumableMap.set(name, { consumable: consumable, properties: matchingProperties });
       }
     }
   }
@@ -1173,17 +1115,13 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       };
     };
 
-    const maxLifetimes = config.consumables?.maxLifetimes || {
-      mainBrush: 18000,
-      sideBrush: 12000,
-      dustFilter: 9000,
-      sensor: 1800,
-    };
-    const warningThreshold = config.consumables?.warningThreshold || 10;
+    const warningThreshold = (config.consumables?.warningThreshold || 10) / 100;
 
     try {
       const consumables = await vacuum.client.getConsumables();
       if (!consumables) return;
+      const consumableProperties = await vacuum.client.getConsumablesProperties();
+      if (!consumableProperties) return;
 
       for (const consumable of consumables) {
         const name = this.getConsumableName(consumable);
@@ -1191,17 +1129,14 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
         if (!entry) continue;
 
-        const maxLifetime = this.getMaxLifetime(consumable, maxLifetimes);
-        const remainingMinutes = consumable.remaining.value;
-        const lifePercent = Math.round((remainingMinutes / maxLifetime) * 100);
-
-        entry.consumable = consumable;
-        const needsReplacement = lifePercent <= warningThreshold;
+        const remaining = consumable.remaining.value;
+        entry.consumable.remaining.value = remaining;
+        const needsReplacement = remaining / entry.properties.maxValue <= warningThreshold;
 
         // Log status change
         if (entry.lastState === undefined || entry.lastState !== needsReplacement) {
           const status = needsReplacement ? '⚠️ NEEDS REPLACEMENT' : '✓ OK';
-          this.log.info(`[${vacuum.name}] ${name}: ${remainingMinutes}min (${lifePercent}%) - ${status}`);
+          this.log.info(`[${vacuum.name}] ${name}: ${remaining} ${consumable.remaining.unit} - ${status}`);
           entry.lastState = needsReplacement;
         }
 
@@ -1221,24 +1156,24 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
   private mapValetudoStatusToOperationalState(status: string, dockStatus?: string): number {
     const statusLower = status.toLowerCase();
 
-    const statusMap: Record<string, number> = {
-      idle: OperationalStateValue.Docked,
-      docked: OperationalStateValue.Docked,
-      cleaning: OperationalStateValue.Running,
-      returning: OperationalStateValue.SeekingCharger,
-      manual_control: OperationalStateValue.Running,
-      moving: OperationalStateValue.Docked,
-      paused: OperationalStateValue.Paused,
-      error: OperationalStateValue.Error,
-      charging: OperationalStateValue.Charging,
+    const statusMap: Record<string, RvcOperationalState.OperationalState> = {
+      idle: RvcOperationalState.OperationalState.Docked,
+      docked: RvcOperationalState.OperationalState.Docked,
+      cleaning: RvcOperationalState.OperationalState.Running,
+      returning: RvcOperationalState.OperationalState.SeekingCharger,
+      manual_control: RvcOperationalState.OperationalState.Running,
+      moving: RvcOperationalState.OperationalState.Docked,
+      paused: RvcOperationalState.OperationalState.Paused,
+      error: RvcOperationalState.OperationalState.Error,
+      charging: RvcOperationalState.OperationalState.Charging,
     };
 
-    const baseState = statusMap[statusLower] ?? OperationalStateValue.Stopped;
+    const baseState = statusMap[statusLower] ?? RvcOperationalState.OperationalState.Stopped;
 
     if (dockStatus && (statusLower === 'docked' || statusLower === 'idle' || statusLower === 'charging')) {
       const dockStatusLower = dockStatus.toLowerCase();
       if (dockStatusLower === 'emptying' || dockStatusLower === 'drying' || dockStatusLower === 'cleaning') {
-        return OperationalStateValue.Docked;
+        return RvcOperationalState.OperationalState.Docked;
       }
     }
 
@@ -1259,77 +1194,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
   }
 
   /**
-   * Get fan and water settings from mode number
-   */
-  /*
-  private getIntensitySettings(mode: number): { fan: string; water: string } {
-    let intensityKey: 'auto' | 'quiet' | 'quick' | 'max';
-    let defaultFan: string;
-    let defaultWater: string;
-
-    if (mode >= RvcCleanModeValue.VacuumQuiet && mode <= RvcCleanModeValue.VacuumTurbo) {
-      const offset = mode - RvcCleanModeValue.VacuumQuiet;
-      const offsetMap: Record<number, { key: 'auto' | 'quiet' | 'quick' | 'max'; fan: string; water: string }> = {
-        0: { key: 'quiet', fan: 'low', water: 'low' },
-        1: { key: 'auto', fan: 'medium', water: 'medium' },
-        2: { key: 'quick', fan: 'high', water: 'high' },
-        3: { key: 'max', fan: 'max', water: 'high' },
-        4: { key: 'max', fan: 'turbo', water: 'high' },
-      };
-      const mapping = offsetMap[offset] || offsetMap[1];
-      intensityKey = mapping.key;
-      defaultFan = mapping.fan;
-      defaultWater = mapping.water;
-    } else if (mode >= RvcCleanModeValue.MopMin && mode <= RvcCleanModeValue.MopHigh) {
-      const modeMap: Record<number, { key: 'auto' | 'quiet' | 'quick' | 'max'; fan: string; water: string }> = {
-        [RvcCleanModeValue.MopMin]: { key: 'auto', fan: 'medium', water: 'medium' },
-        [RvcCleanModeValue.MopLow]: { key: 'quiet', fan: 'low', water: 'low' },
-        [RvcCleanModeValue.MopMedium]: { key: 'quick', fan: 'high', water: 'high' },
-        [RvcCleanModeValue.MopHigh]: { key: 'max', fan: 'max', water: 'high' },
-      };
-      const mapping = modeMap[mode] || modeMap[RvcCleanModeValue.MopMin];
-      intensityKey = mapping.key;
-      defaultFan = mapping.fan;
-      defaultWater = mapping.water;
-    } else if (mode >= RvcCleanModeValue.VacuumMopQuiet && mode <= RvcCleanModeValue.VacuumMopTurbo) {
-      const offset = mode - RvcCleanModeValue.VacuumMopQuiet;
-      const offsetMap: Record<number, { key: 'auto' | 'quiet' | 'quick' | 'max'; fan: string; water: string }> = {
-        0: { key: 'quiet', fan: 'low', water: 'low' },
-        1: { key: 'auto', fan: 'medium', water: 'medium' },
-        2: { key: 'quick', fan: 'high', water: 'high' },
-        3: { key: 'max', fan: 'max', water: 'high' },
-        4: { key: 'max', fan: 'turbo', water: 'high' },
-      };
-      const mapping = offsetMap[offset] || offsetMap[1];
-      intensityKey = mapping.key;
-      defaultFan = mapping.fan;
-      defaultWater = mapping.water;
-    } else {
-      return { fan: 'medium', water: 'medium' };
-    }
-
-    const config = this.config as {
-      intensityPresets?: {
-        auto?: { fanSpeed?: string; waterUsage?: string };
-        quiet?: { fanSpeed?: string; waterUsage?: string };
-        quick?: { fanSpeed?: string; waterUsage?: string };
-        max?: { fanSpeed?: string; waterUsage?: string };
-      };
-    };
-
-    const overrides = config.intensityPresets?.[intensityKey];
-
-    return {
-      fan: overrides?.fanSpeed || defaultFan,
-      water: overrides?.waterUsage || defaultWater,
-    };
-  }
-  */
-
-  /**
    * Get friendly name for a consumable
    */
-  private getConsumableName(consumable: ValetudoConsumable): string {
+  private getConsumableName(consumable: ValetudoConsumable | ConsumableProperties): string {
     const typeMap: Record<string, string> = {
       'brush-main': 'Main Brush',
       'brush-side_right': 'Side Brush',

--- a/src/module.ts
+++ b/src/module.ts
@@ -1265,11 +1265,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
   /**
    * Resolve the effective maxValue for a consumable, applying user overrides from maxLifetimes config
    */
-  private getConsumableMaxValue(
-    consumable: { type: string; subType: string },
-    apiMaxValue: number,
-    maxLifetimes?: Record<string, number>,
-  ): number {
+  private getConsumableMaxValue(consumable: { type: string; subType: string }, apiMaxValue: number, maxLifetimes?: Record<string, number>): number {
     if (!maxLifetimes) return apiMaxValue;
 
     // Map consumable type+subType to config key

--- a/src/module.ts
+++ b/src/module.ts
@@ -493,13 +493,19 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         vacuum_and_mop: new Map(),
         vacuum_then_mop: new Map(),
       };
+      const validOperationModes = new Set<string>(Object.keys(tagPresetMap));
+
       for (const opMode of operatingModes) {
+        if (!validOperationModes.has(opMode)) {
+          this.log.warn(`  Skipping unknown operation mode from API: "${opMode}"`);
+          continue;
+        }
         if (opMode === 'vacuum' && fanSpeedPresets) {
-          fanSpeedPresets.forEach((preset, _) => {
+          fanSpeedPresets.forEach((preset) => {
             tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { fanSpeed: preset });
           });
         } else if (opMode === 'mop' && waterUsagePresets) {
-          waterUsagePresets.forEach((preset, _) => {
+          waterUsagePresets.forEach((preset) => {
             tagPresetMap[opMode].set(defaultPresetToTagMap[preset], { waterUsage: preset });
           });
         } else if ((opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop') && fanSpeedPresets && waterUsagePresets) {
@@ -520,7 +526,15 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
           const selectedModes = tagGroup.operationModes || [];
           const mappings = tagGroup.mappings || [];
           for (const opMode of selectedModes) {
+            if (!validOperationModes.has(opMode)) {
+              this.log.warn(`  customTags: skipping unknown operation mode "${opMode}"`);
+              continue;
+            }
             for (const mapping of mappings) {
+              if (typeof mapping.matterModeTag !== 'number') {
+                this.log.warn(`  customTags: skipping mapping with invalid matterModeTag: ${JSON.stringify(mapping.matterModeTag)}`);
+                continue;
+              }
               tagPresetMap[opMode].set(mapping.matterModeTag, {
                 fanSpeed: mapping.fanSpeed,
                 waterUsage: mapping.waterUsage,

--- a/src/module.ts
+++ b/src/module.ts
@@ -32,7 +32,6 @@ interface VacuumInstance {
 
   // Per-vacuum state
   capabilities: string[];
-  operationModes: string[];
   modeMap: Map<number, { fanSpeed?: PresetLevel; waterUsage?: PresetLevel; operationMode?: ValetudoOperationMode }>;
   areaToSegmentMap: Map<number, { id: string; name: string }>;
   selectedSegmentIds: string[];
@@ -290,7 +289,6 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       device: null,
       pollingInterval: null,
       capabilities: [],
-      operationModes: [],
       areaToSegmentMap: new Map(),
       modeMap: new Map(),
       selectedSegmentIds: [],
@@ -849,7 +847,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       const name = this.getConsumableName(consumable);
       const matchingProperties = consumableProperties?.find((prop) => prop.type === consumable.type && prop.subType === consumable.subType);
       if (!matchingProperties) {
-        this.log.info(`No properties fround for consumable ${name}`);
+        this.log.info(`No properties found for consumable ${name}`);
         continue;
       }
       const remaining = consumable.remaining.value;
@@ -1174,7 +1172,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       cleaning: RvcOperationalState.OperationalState.Running,
       returning: RvcOperationalState.OperationalState.SeekingCharger,
       manual_control: RvcOperationalState.OperationalState.Running,
-      moving: RvcOperationalState.OperationalState.Docked,
+      moving: RvcOperationalState.OperationalState.Running,
       paused: RvcOperationalState.OperationalState.Paused,
       error: RvcOperationalState.OperationalState.Error,
       charging: RvcOperationalState.OperationalState.Charging,

--- a/src/module.ts
+++ b/src/module.ts
@@ -642,7 +642,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
               fanSpeed: override.fanSpeed ?? existing.fanSpeed,
               waterUsage: override.waterUsage ?? existing.waterUsage,
             });
-            this.log.info(`  intensityOverrides: ${categoryConfig[cat].label} @ ${override.intensity} → fan=${override.fanSpeed ?? 'default'}, water=${override.waterUsage ?? 'default'}`);
+            this.log.info(
+              `  intensityOverrides: ${categoryConfig[cat].label} @ ${override.intensity} → fan=${override.fanSpeed ?? 'default'}, water=${override.waterUsage ?? 'default'}`,
+            );
           }
         }
       }
@@ -716,9 +718,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         const legacyTag = defaultPresetToTagMap[legacy.preset];
         const legacyCat = legacy.category as MatterCategory;
         const overriddenPresets = categoryPresetMap[legacyCat]?.get(legacyTag);
-        const effectivePreset = overriddenPresets
-          ? (overriddenPresets.fanSpeed || overriddenPresets.waterUsage || legacy.preset)
-          : legacy.preset;
+        const effectivePreset = overriddenPresets ? overriddenPresets.fanSpeed || overriddenPresets.waterUsage || legacy.preset : legacy.preset;
         supportedCleanModes.push({
           label: legacy.label,
           mode: legacy.id,
@@ -737,7 +737,12 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       }
       const realModes = supportedCleanModes.filter((m) => !vacuum.modeMap.get(m.mode)?.isLegacy);
       this.log.info(`  Clean modes (${realModes.length}): ${realModes.map((m) => `${m.label}(${m.mode})`).join(', ')}`);
-      this.log.debug(`  Legacy compat modes: ${supportedCleanModes.filter((m) => vacuum.modeMap.get(m.mode)?.isLegacy).map((m) => `${m.label}(${m.mode})`).join(', ')}`);
+      this.log.debug(
+        `  Legacy compat modes: ${supportedCleanModes
+          .filter((m) => vacuum.modeMap.get(m.mode)?.isLegacy)
+          .map((m) => `${m.label}(${m.mode})`)
+          .join(', ')}`,
+      );
       this.log.debug(`Supported clean modes: ${JSON.stringify(supportedCleanModes)}`);
 
       // Create Matter device
@@ -873,7 +878,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
     // Change mode command (handles both run mode and clean mode)
     vacuum.device.addCommandHandler('changeToMode', async (data: { request: Record<string, unknown> }) => {
-      this.log.info(`[${vacuum.name}] changeToMode called: ${JSON.stringify(data, (_, v) => typeof v === 'bigint' ? Number(v) : v)}`);
+      this.log.info(`[${vacuum.name}] changeToMode called: ${JSON.stringify(data, (_, v) => (typeof v === 'bigint' ? Number(v) : v))}`);
 
       const request = data.request as { newMode: number };
       const isRunMode = request.newMode >= 1 && request.newMode <= 3;
@@ -935,7 +940,9 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
               const waterPreset = vacuum.waterUsagePresets?.includes(presetLevel) ? presetLevel : vacuum.waterUsagePresets?.[vacuum.waterUsagePresets.length - 1];
               if (waterPreset) {
                 if (waterPreset !== presetLevel) {
-                  this.log.warn(`[${vacuum.name}] Water usage '${presetLevel}' not supported, falling back to '${waterPreset}'. Available: ${vacuum.waterUsagePresets?.join(', ')}`);
+                  this.log.warn(
+                    `[${vacuum.name}] Water usage '${presetLevel}' not supported, falling back to '${waterPreset}'. Available: ${vacuum.waterUsagePresets?.join(', ')}`,
+                  );
                 }
                 this.log.info(`[${vacuum.name}] Setting water '${waterPreset}'`);
                 await vacuum.client.setWaterUsage(waterPreset);
@@ -966,7 +973,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
 
     // Select areas command
     vacuum.device.addCommandHandler('selectAreas', async (data: { request: Record<string, unknown> }) => {
-      this.log.info(`[${vacuum.name}] selectAreas called: ${JSON.stringify(data, (_, v) => typeof v === 'bigint' ? Number(v) : v)}`);
+      this.log.info(`[${vacuum.name}] selectAreas called: ${JSON.stringify(data, (_, v) => (typeof v === 'bigint' ? Number(v) : v))}`);
 
       const request = data.request as { newAreas?: number[] };
 
@@ -1141,9 +1148,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
   private syncOperationModeFromAttributes(vacuum: VacuumInstance, attributes: Array<{ __class: string; type?: string; value?: unknown }>): void {
     if (!vacuum.capabilities.includes('OperationModeControlCapability')) return;
 
-    const opModeAttr = attributes.find((attr) => attr.__class === 'PresetSelectionStateAttribute' && attr.type === 'operation_mode') as
-      | { value: string }
-      | undefined;
+    const opModeAttr = attributes.find((attr) => attr.__class === 'PresetSelectionStateAttribute' && attr.type === 'operation_mode') as { value: string } | undefined;
 
     if (opModeAttr?.value) {
       const newOpMode = opModeAttr.value as ValetudoOperationMode;

--- a/src/module.ts
+++ b/src/module.ts
@@ -504,6 +504,18 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         custom: RvcCleanMode.ModeTag.LowNoise,
       };
 
+      // Matter intensity labels (as shown in the user's smart home controller) → Matter tags
+      // Used for intensityOverrides config where users pick labels they see in their controller
+      const matterLabelToTag: Record<string, RvcCleanMode.ModeTag> = {
+        Min: RvcCleanMode.ModeTag.Min,
+        Quiet: RvcCleanMode.ModeTag.Quiet,
+        Auto: RvcCleanMode.ModeTag.Auto,
+        Quick: RvcCleanMode.ModeTag.Quick,
+        Max: RvcCleanMode.ModeTag.Max,
+        DeepClean: RvcCleanMode.ModeTag.DeepClean,
+        LowNoise: RvcCleanMode.ModeTag.LowNoise,
+      };
+
       const config = this.config as {
         operationModeMapping?: {
           vacuum?: ValetudoOperationMode;
@@ -512,7 +524,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         };
         intensityOverrides?: Array<{
           category?: 'vacuum' | 'mop' | 'vacuumAndMop';
-          intensity: PresetLevel;
+          intensity: 'Min' | 'Quiet' | 'Auto' | 'Quick' | 'Max' | 'DeepClean' | 'LowNoise';
           fanSpeed?: PresetLevel;
           waterUsage?: PresetLevel;
         }>;
@@ -602,11 +614,13 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       }
 
       // Apply intensity overrides
+      // The intensity field uses Matter labels (Min, Quiet, Auto, Quick, Max, DeepClean, LowNoise)
+      // which map to what the user sees in their smart home controller
       if (config.intensityOverrides && config.intensityOverrides.length > 0) {
         for (const override of config.intensityOverrides) {
-          const matterTag = defaultPresetToTagMap[override.intensity];
+          const matterTag = matterLabelToTag[override.intensity];
           if (matterTag === undefined) {
-            this.log.warn(`  intensityOverrides: skipping unknown intensity "${override.intensity}"`);
+            this.log.warn(`  intensityOverrides: skipping unknown intensity "${override.intensity}". Valid values: ${Object.keys(matterLabelToTag).join(', ')}`);
             continue;
           }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -512,6 +512,13 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
       };
 
       const config = this.config as {
+        modeOverrides?: Array<{
+          operationMode: ValetudoOperationMode;
+          intensity: PresetLevel;
+          fanSpeed?: PresetLevel;
+          waterUsage?: PresetLevel;
+        }>;
+        // Deprecated: old customTags format, kept for backward compatibility
         customTags?: Array<{
           operationModes: Array<ValetudoOperationMode>;
           mappings: Array<{
@@ -557,21 +564,39 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         }
       }
 
-      // Apply custom tag overrides
+      // Apply mode overrides: user can customize what presets are applied for each mode
+      if (config.modeOverrides && config.modeOverrides.length > 0) {
+        for (const override of config.modeOverrides) {
+          if (!validOperationModes.has(override.operationMode)) {
+            this.log.warn(`  modeOverrides: skipping unknown operation mode "${override.operationMode}"`);
+            continue;
+          }
+          const matterTag = defaultPresetToTagMap[override.intensity];
+          if (matterTag === undefined) {
+            this.log.warn(`  modeOverrides: skipping unknown intensity "${override.intensity}"`);
+            continue;
+          }
+          this.log.info(`  modeOverrides: ${override.operationMode} @ ${override.intensity} → fan=${override.fanSpeed ?? 'default'}, water=${override.waterUsage ?? 'default'}`);
+
+          // Get existing defaults and merge overrides on top
+          const existing = tagPresetMap[override.operationMode].get(matterTag) ?? {};
+          tagPresetMap[override.operationMode].set(matterTag, {
+            fanSpeed: override.fanSpeed ?? existing.fanSpeed,
+            waterUsage: override.waterUsage ?? existing.waterUsage,
+          });
+        }
+      }
+
+      // Backward compatibility: support deprecated customTags format
       if (config.customTags && config.customTags.length > 0) {
+        this.log.warn('DEPRECATED: "customTags" config is replaced by "modeOverrides". Please update your configuration.');
         for (const tagGroup of config.customTags) {
           const selectedModes = tagGroup.operationModes || [];
           const mappings = tagGroup.mappings || [];
           for (const opMode of selectedModes) {
-            if (!validOperationModes.has(opMode)) {
-              this.log.warn(`  customTags: skipping unknown operation mode "${opMode}"`);
-              continue;
-            }
+            if (!validOperationModes.has(opMode)) continue;
             for (const mapping of mappings) {
-              if (typeof mapping.matterModeTag !== 'number') {
-                this.log.warn(`  customTags: skipping mapping with invalid matterModeTag: ${JSON.stringify(mapping.matterModeTag)}`);
-                continue;
-              }
+              if (typeof mapping.matterModeTag !== 'number') continue;
               tagPresetMap[opMode].set(mapping.matterModeTag, {
                 fanSpeed: mapping.fanSpeed,
                 waterUsage: mapping.waterUsage,

--- a/src/module.ts
+++ b/src/module.ts
@@ -33,7 +33,7 @@ interface VacuumInstance {
 
   // Per-vacuum state
   capabilities: string[];
-  modeMap: Map<number, { presetLevel: PresetLevel; isLegacy?: boolean }>;
+  modeMap: Map<number, { presetLevel?: PresetLevel; setOperationMode?: ValetudoOperationMode; isLegacy?: boolean }>;
   currentOperationMode: ValetudoOperationMode;
   fanSpeedPresets: PresetLevel[] | null;
   waterUsagePresets: PresetLevel[] | null;
@@ -583,6 +583,37 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         modeId++;
       }
 
+      // Add operation mode selectors so users can switch between vacuum/mop/combo from Matter.
+      // These are separate from intensity modes — selecting one changes the vacuum's operation
+      // mode without changing the intensity level.
+      const valetudoToMatterTags: Record<ValetudoOperationMode, RvcCleanMode.ModeTag[]> = {
+        vacuum: [RvcCleanMode.ModeTag.Vacuum],
+        mop: [RvcCleanMode.ModeTag.Mop],
+        vacuum_and_mop: [RvcCleanMode.ModeTag.Vacuum, RvcCleanMode.ModeTag.Mop],
+        vacuum_then_mop: [RvcCleanMode.ModeTag.VacuumThenMop],
+      };
+      const opModeLabelMap: Record<string, string> = {
+        vacuum: 'Vacuum Mode',
+        mop: 'Mop Mode',
+        vacuum_and_mop: 'Vacuum & Mop Mode',
+        vacuum_then_mop: 'Vacuum Then Mop Mode',
+      };
+      for (const opMode of operatingModes) {
+        const opModeTyped = opMode as ValetudoOperationMode;
+        const opTags = valetudoToMatterTags[opModeTyped];
+        if (!opTags) continue;
+
+        const label = opModeLabelMap[opMode] || opMode;
+        this.log.debug(`Building operation mode: ${opMode} → ID ${modeId}, label "${label}"`);
+        supportedCleanModes.push({
+          label,
+          mode: modeId,
+          modeTags: [...opTags.map((tag) => ({ value: tag })), { value: RvcCleanMode.ModeTag.Auto }],
+        });
+        vacuum.modeMap.set(modeId, { setOperationMode: opModeTyped });
+        modeId++;
+      }
+
       // Legacy v1.0.7 compatibility: add mode IDs that may be persisted from previous versions.
       // Without these, upgrading from v1.0.7 crashes because the persisted currentMode is not
       // in the supported modes list, and Matter.js validates this during initialization before
@@ -618,7 +649,8 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         });
         vacuum.modeMap.set(RvcCleanModeBase, { presetLevel: 'medium' });
       }
-      this.log.info(`  Clean modes: ${supportedCleanModes.filter((m) => !vacuum.modeMap.get(m.mode)?.isLegacy).map((m) => `${m.label}(${m.mode})`).join(', ')}`);
+      const realModes = supportedCleanModes.filter((m) => { const c = vacuum.modeMap.get(m.mode); return !c?.isLegacy; });
+      this.log.info(`  Clean modes (${realModes.length}): ${realModes.map((m) => `${m.label}(${m.mode})`).join(', ')}`);
       this.log.debug(`  Legacy compat modes: ${supportedCleanModes.filter((m) => vacuum.modeMap.get(m.mode)?.isLegacy).map((m) => `${m.label}(${m.mode})`).join(', ')}`);
       this.log.debug(`Supported clean modes: ${JSON.stringify(supportedCleanModes)}`);
 
@@ -779,7 +811,7 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
           vacuum.selectedRoomNames = [];
         }
       } else {
-        // Clean mode change — shared intensity modes apply to the current operation mode
+        // Clean mode change
         const modeConfig = vacuum.modeMap.get(request.newMode);
 
         if (modeConfig) {
@@ -787,31 +819,42 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
             this.log.info(`[${vacuum.name}] Legacy mode ${request.newMode} selected, mapping to preset '${modeConfig.presetLevel}'`);
           }
 
-          const presetLevel = modeConfig.presetLevel;
-          const opMode = vacuum.currentOperationMode;
+          if (modeConfig.setOperationMode) {
+            // Operation mode selector — switch the vacuum's operation mode
+            const newOpMode = modeConfig.setOperationMode;
+            this.log.info(`[${vacuum.name}] Switching operation mode to '${newOpMode}'`);
+            vacuum.currentOperationMode = newOpMode;
 
-          // Set operation mode if the vacuum supports it
-          if (vacuum.capabilities.includes('OperationModeControlCapability')) {
-            this.log.info(`[${vacuum.name}] Setting operation mode '${opMode}'`);
-            await vacuum.client.setOperationMode(opMode);
-          }
-
-          // Apply fan speed for vacuum-related modes
-          if (vacuum.capabilities.includes('FanSpeedControlCapability') && (opMode === 'vacuum' || opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop')) {
-            // Use the preset directly if available, otherwise fall back to the closest available preset
-            const fanPreset = vacuum.fanSpeedPresets?.includes(presetLevel) ? presetLevel : vacuum.fanSpeedPresets?.[vacuum.fanSpeedPresets.length - 1];
-            if (fanPreset) {
-              this.log.info(`[${vacuum.name}] Setting fan '${fanPreset}'`);
-              await vacuum.client.setFanSpeed(fanPreset);
+            if (vacuum.capabilities.includes('OperationModeControlCapability')) {
+              await vacuum.client.setOperationMode(newOpMode);
             }
-          }
+          } else if (modeConfig.presetLevel) {
+            // Intensity mode — apply preset to the current operation mode
+            const presetLevel = modeConfig.presetLevel;
+            const opMode = vacuum.currentOperationMode;
 
-          // Apply water usage for mop-related modes
-          if (vacuum.capabilities.includes('WaterUsageControlCapability') && (opMode === 'mop' || opMode === 'vacuum_and_mop')) {
-            const waterPreset = vacuum.waterUsagePresets?.includes(presetLevel) ? presetLevel : vacuum.waterUsagePresets?.[vacuum.waterUsagePresets.length - 1];
-            if (waterPreset) {
-              this.log.info(`[${vacuum.name}] Setting water '${waterPreset}'`);
-              await vacuum.client.setWaterUsage(waterPreset);
+            // Set operation mode if the vacuum supports it
+            if (vacuum.capabilities.includes('OperationModeControlCapability')) {
+              this.log.info(`[${vacuum.name}] Setting operation mode '${opMode}'`);
+              await vacuum.client.setOperationMode(opMode);
+            }
+
+            // Apply fan speed for vacuum-related modes
+            if (vacuum.capabilities.includes('FanSpeedControlCapability') && (opMode === 'vacuum' || opMode === 'vacuum_and_mop' || opMode === 'vacuum_then_mop')) {
+              const fanPreset = vacuum.fanSpeedPresets?.includes(presetLevel) ? presetLevel : vacuum.fanSpeedPresets?.[vacuum.fanSpeedPresets.length - 1];
+              if (fanPreset) {
+                this.log.info(`[${vacuum.name}] Setting fan '${fanPreset}'`);
+                await vacuum.client.setFanSpeed(fanPreset);
+              }
+            }
+
+            // Apply water usage for mop-related modes
+            if (vacuum.capabilities.includes('WaterUsageControlCapability') && (opMode === 'mop' || opMode === 'vacuum_and_mop')) {
+              const waterPreset = vacuum.waterUsagePresets?.includes(presetLevel) ? presetLevel : vacuum.waterUsagePresets?.[vacuum.waterUsagePresets.length - 1];
+              if (waterPreset) {
+                this.log.info(`[${vacuum.name}] Setting water '${waterPreset}'`);
+                await vacuum.client.setWaterUsage(waterPreset);
+              }
             }
           }
         }

--- a/src/module.ts
+++ b/src/module.ts
@@ -666,11 +666,21 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         }
       }
 
-      // Legacy v1.0.7 compatibility: add mode IDs that may be persisted from previous versions.
-      // Without these, upgrading from v1.0.7 crashes because the persisted currentMode is not
-      // in the supported modes list, and Matter.js validates this during initialization before
-      // the plugin can intervene.
-      // v1.0.7 mode IDs: VacuumMop 5-9 (overlap with new), Mop 31-34, Vacuum 66-70
+      // Legacy v1.0.7 compatibility mode IDs.
+      //
+      // Why these exist: Matter.js persists the current rvcCleanMode mode ID. When the plugin
+      // restarts, Matter.js validates the persisted currentMode against supportedModes BEFORE
+      // the plugin can intervene. v1.0.8 renumbered all modes (starting from RvcCleanModeBase),
+      // so a vacuum that was last set to e.g. mode 70 ("Vacuum Turbo" in v1.0.7) would fail
+      // validation and crash on startup. These ghost entries keep the old IDs valid.
+      //
+      // Important: legacy modes share the same Matter intensity tags (DeepClean, Quick, etc.)
+      // as real modes. Controllers like Apple Home may select a legacy mode instead of the real
+      // one when both have the same tag. To handle this, legacy modes inherit any intensity
+      // overrides from categoryPresetMap so they behave identically to their real counterparts.
+      //
+      // These can be removed once enough upgrade cycles have passed that no persisted state
+      // references the old IDs (v1.0.7 IDs: VacuumMop 5-9, Mop 31-34, Vacuum 66-70).
       const legacyTagMap: Record<string, RvcCleanMode.ModeTag[]> = {
         vacuum: [RvcCleanMode.ModeTag.Vacuum],
         mop: [RvcCleanMode.ModeTag.Mop],
@@ -690,12 +700,21 @@ export class ValetudoPlatform extends MatterbridgeDynamicPlatform {
         // Skip if this ID is already used by a real mode
         if (vacuum.modeMap.has(legacy.id)) continue;
         const legacyOpTags = legacyTagMap[legacy.category] || [RvcCleanMode.ModeTag.Vacuum];
+        // Inherit overridden presets from categoryPresetMap so intensity overrides
+        // apply to legacy modes too (Apple Home may pick a legacy mode over the real one
+        // when both share the same intensity tag)
+        const legacyTag = defaultPresetToTagMap[legacy.preset];
+        const legacyCat = legacy.category as MatterCategory;
+        const overriddenPresets = categoryPresetMap[legacyCat]?.get(legacyTag);
+        const effectivePreset = overriddenPresets
+          ? (overriddenPresets.fanSpeed || overriddenPresets.waterUsage || legacy.preset)
+          : legacy.preset;
         supportedCleanModes.push({
           label: legacy.label,
           mode: legacy.id,
-          modeTags: [...legacyOpTags.map((tag) => ({ value: tag })), { value: defaultPresetToTagMap[legacy.preset] }],
+          modeTags: [...legacyOpTags.map((tag) => ({ value: tag })), { value: legacyTag }],
         });
-        vacuum.modeMap.set(legacy.id, { presetLevel: legacy.preset, setOperationMode: legacy.valetudoMode, isLegacy: true });
+        vacuum.modeMap.set(legacy.id, { presetLevel: effectivePreset, setOperationMode: legacy.valetudoMode, isLegacy: true });
       }
 
       if (supportedCleanModes.length === 0) {

--- a/src/valetudo-client.ts
+++ b/src/valetudo-client.ts
@@ -232,7 +232,7 @@ export class ValetudoClient {
     try {
       const url = `${this.baseUrl}/api/v2/valetudo/config/customizations`;
       const data = await this.httpGet(url);
-      this.log.debug(`Customizations recieved: ${JSON.stringify(data)}`);
+      this.log.debug(`Customizations received: ${JSON.stringify(data)}`);
       return data as ValetudoCustomizations;
     } catch (error) {
       this.log.error(`Error fetching customizations: ${error instanceof Error ? error.message : String(error)}`);
@@ -676,6 +676,7 @@ export class ValetudoClient {
           let data = '';
 
           if (res.statusCode !== 200) {
+            res.resume(); // Drain response to free the socket
             const error = new Error(`HTTP GET failed with status code: ${res.statusCode} for ${url}`);
             this.log.error(error.message);
             reject(error);
@@ -750,6 +751,7 @@ export class ValetudoClient {
         let data = '';
 
         if (res.statusCode !== 200) {
+          res.resume(); // Drain response to free the socket
           const error = new Error(`HTTP PUT failed with status code: ${res.statusCode} for ${url}`);
           this.log.error(error.message);
           reject(error);

--- a/src/valetudo-client.ts
+++ b/src/valetudo-client.ts
@@ -35,7 +35,10 @@ export interface ValetudoCustomizations {
 export type BatteryFlag = 'none' | 'charging' | 'discharging' | 'charged';
 export type AttachmentType = 'dustbin' | 'watertank' | 'mop';
 export type PresetType = 'fan_speed' | 'water_grade' | 'operation_mode';
-export type PresetValue = 'off' | 'min' | 'low' | 'medium' | 'high' | 'max' | 'turbo' | 'custom' | 'vacuum' | 'mop' | 'vacuum_and_mop' | 'vacuum_then_mop';
+export type PresetLevel = 'off' | 'min' | 'low' | 'medium' | 'high' | 'max' | 'turbo' | 'custom';
+export type ValetudoOperationMode = 'vacuum' | 'mop' | 'vacuum_and_mop' | 'vacuum_then_mop';
+export type PresetValue = PresetLevel | ValetudoOperationMode;
+export type ConsumableUnit = 'percent' | 'minutes';
 
 export interface BatteryStateAttribute {
   __class: 'BatteryStateAttribute';
@@ -80,7 +83,7 @@ export interface MapSegment {
 
 export interface ConsumableRemaining {
   value: number;
-  unit: 'percent' | 'minutes';
+  unit: ConsumableUnit;
 }
 
 export interface ValetudoConsumable {
@@ -88,6 +91,13 @@ export interface ValetudoConsumable {
   type: string;
   subType: string;
   remaining: ConsumableRemaining;
+}
+
+export interface ConsumableProperties {
+  type: string;
+  subType: string;
+  unit: ConsumableUnit;
+  maxValue: number;
 }
 
 export interface ValetudoDataPoint {
@@ -357,10 +367,10 @@ export class ValetudoClient {
   /**
    * Get available fan speed presets
    */
-  async getFanSpeedPresets(): Promise<string[] | null> {
+  async getFanSpeedPresets(): Promise<PresetLevel[] | null> {
     try {
       const data = await this.httpGet(`${this.baseUrl}/api/v2/robot/capabilities/FanSpeedControlCapability/presets`);
-      return data as string[];
+      return data as PresetLevel[];
     } catch (error) {
       this.log.error(`Error fetching fan speed presets: ${error instanceof Error ? error.message : String(error)}`);
       return null;
@@ -372,7 +382,7 @@ export class ValetudoClient {
    *
    * @param preset
    */
-  async setFanSpeed(preset: string): Promise<boolean> {
+  async setFanSpeed(preset: PresetLevel): Promise<boolean> {
     try {
       const result = await this.httpPut(`${this.baseUrl}/api/v2/robot/capabilities/FanSpeedControlCapability/preset`, {
         name: preset,
@@ -387,10 +397,10 @@ export class ValetudoClient {
   /**
    * Get available water usage presets
    */
-  async getWaterUsagePresets(): Promise<string[] | null> {
+  async getWaterUsagePresets(): Promise<PresetLevel[] | null> {
     try {
       const data = await this.httpGet(`${this.baseUrl}/api/v2/robot/capabilities/WaterUsageControlCapability/presets`);
-      return data as string[];
+      return data as PresetLevel[];
     } catch (error) {
       this.log.error(`Error fetching water usage presets: ${error instanceof Error ? error.message : String(error)}`);
       return null;
@@ -402,7 +412,7 @@ export class ValetudoClient {
    *
    * @param preset
    */
-  async setWaterUsage(preset: string): Promise<boolean> {
+  async setWaterUsage(preset: PresetLevel): Promise<boolean> {
     try {
       const result = await this.httpPut(`${this.baseUrl}/api/v2/robot/capabilities/WaterUsageControlCapability/preset`, {
         name: preset,
@@ -417,10 +427,10 @@ export class ValetudoClient {
   /**
    * Get available operation mode presets
    */
-  async getOperationModePresets(): Promise<string[] | null> {
+  async getOperationModePresets(): Promise<ValetudoOperationMode[] | null> {
     try {
       const data = await this.httpGet(`${this.baseUrl}/api/v2/robot/capabilities/OperationModeControlCapability/presets`);
-      return data as string[];
+      return data as ValetudoOperationMode[];
     } catch (error) {
       this.log.error(`Error fetching operation mode presets: ${error instanceof Error ? error.message : String(error)}`);
       return null;
@@ -432,7 +442,7 @@ export class ValetudoClient {
    *
    * @param preset
    */
-  async setOperationMode(preset: string): Promise<boolean> {
+  async setOperationMode(preset: ValetudoOperationMode): Promise<boolean> {
     try {
       const result = await this.httpPut(`${this.baseUrl}/api/v2/robot/capabilities/OperationModeControlCapability/preset`, {
         name: preset,
@@ -623,6 +633,19 @@ export class ValetudoClient {
       return data as ValetudoConsumable[];
     } catch (error) {
       this.log.error(`Error fetching consumables: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+  }
+
+  /**
+   * Get consumables properties (max lifetime etc.)
+   */
+  async getConsumablesProperties(): Promise<ConsumableProperties[] | null> {
+    try {
+      const data = (await this.httpGet(`${this.baseUrl}/api/v2/robot/capabilities/ConsumableMonitoringCapability/properties`)) as { availableConsumables: ConsumableProperties[] };
+      return data.availableConsumables;
+    } catch (error) {
+      this.log.error(`Error fetching available consumables: ${error instanceof Error ? error.message : String(error)}`);
       return null;
     }
   }

--- a/src/valetudo-client.ts
+++ b/src/valetudo-client.ts
@@ -28,6 +28,10 @@ export interface ValetudoRobotInfo {
   implementation: string;
 }
 
+export interface ValetudoCustomizations {
+  friendlyName?: string;
+}
+
 export type BatteryFlag = 'none' | 'charging' | 'discharging' | 'charged';
 export type AttachmentType = 'dustbin' | 'watertank' | 'mop';
 export type PresetType = 'fan_speed' | 'water_grade' | 'operation_mode';
@@ -210,6 +214,18 @@ export class ValetudoClient {
       return data as ValetudoInfo;
     } catch (error) {
       this.log.error(`Error fetching Valetudo info: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+  }
+
+  async getCustomizations(): Promise<ValetudoCustomizations | null> {
+    try {
+      const url = `${this.baseUrl}/api/v2/valetudo/config/customizations`;
+      const data = await this.httpGet(url);
+      this.log.debug(`Customizations recieved: ${JSON.stringify(data)}`);
+      return data as ValetudoCustomizations;
+    } catch (error) {
+      this.log.error(`Error fetching customizations: ${error instanceof Error ? error.message : String(error)}`);
       return null;
     }
   }


### PR DESCRIPTION
Bug fixes:
Fix HomeKit automations failing (BigInt serialization crash in selectAreas)
Fix intensityOverrides not applying to legacy compatibility modes
Fix HTTP connection leak, shutdown race, and division by zero
Fix moving status mapping, typo, dead code removal
Fix TypeScript build errors from matterbridge dependency resolution
Fix preset mapping and custom tag mapping
Validate operation modes and customTags to prevent runtime crashes

Features:
Redesigned clean mode system: per-category intensity modes (Vacuum/Mop/Combo)
Operation mode mapping (configurable Valetudo mode per Matter category)
Intensity overrides with Matter labels (Min/Quiet/Auto/Quick/Max/DeepClean/LowNoise)
Preset validation against vacuum capabilities with warnings
Legacy v1.0.7 mode compatibility (prevents crash on upgrade)
Mode mapping contribution from gustavakerstrom (PR #11)

Housekeeping:
Remove leftover jest config files that break lint
Remove node-ansi-logger and node-persist-manager from direct dependencies
Update package-lock.json
Schema dropdowns match common Valetudo presets
Deprecation warnings for old config keys (customTags, modeOverrides)
Fix prettier formatting
.claude/ added to .gitignore
README update